### PR TITLE
[PAGOPA-1203] APIs refactoring

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,1041 +1,988 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "@project.artifactId@",
-    "description": "@project.description@",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.1"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "platform-authorizer-config",
+    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.2.1"
   },
-  "servers": [
-    {
-      "url": "http://localhost",
-      "description": "Generated server url"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Enrolled Orgs",
-      "description": "Everything about enrolled organizations"
-    },
-    {
-      "name": "Cached Authorizations",
-      "description": "Everything about cached authorizations"
-    },
-    {
-      "name": "Authorizations",
-      "description": "Everything about authorizations"
-    }
-  ],
-  "paths": {
-    "/authorizations/{authorizationId}": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization by identifier",
-        "operationId": "getAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Enrolled Orgs",
+    "description" : "Everything about enrolled organizations"
+  }, {
+    "name" : "Cached Authorizations",
+    "description" : "Everything about cached authorizations"
+  }, {
+    "name" : "Authorizations",
+    "description" : "Everything about authorizations"
+  } ],
+  "paths" : {
+    "/authorizations/{authorizationId}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by identifier",
+        "operationId" : "getAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Update existing authorization",
-        "operationId": "updateAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Update existing authorization",
+        "operationId" : "updateAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Delete existing authorization",
-        "operationId": "deleteAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Delete existing authorization",
+        "operationId" : "deleteAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "200" : {
+            "description" : "OK"
           },
-          "403": {
-            "description": "Forbidden"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations/{domain}/refresh": {
-      "post": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Refresh cached authorizations by domain",
-        "operationId": "refreshCachedAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
+    "/cachedauthorizations/{domain}/refresh" : {
+      "post" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Refresh cached authorizations by domain and owner",
+        "operationId" : "refreshCachedAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {}
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "429": {
-            "description": "Too many requests"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/authorizations": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization list",
-        "operationId": "getAuthorizations_1",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+    "/authorizations" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization list",
+        "operationId" : "getAuthorizations_1",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "429": {
-            "description": "Too many requests"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Create new authorization",
-        "operationId": "createAuthorization",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+      "post" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Create new authorization",
+        "operationId" : "createAuthorization",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        "responses" : {
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "429": {
-            "description": "Too many requests"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/organizations/{organizationfiscalcode}/domains/{domain}": {
-      "get": {
-        "tags": [
-          "Enrolled Orgs"
-        ],
-        "summary": "Get list of stations associated to organizations enrolled to a specific domain",
-        "operationId": "getStationsForEnrolledOrganizations",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "The enrolled organization on which the stations will be extracted.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the stations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/domains/{domain}" : {
+      "get" : {
+        "tags" : [ "Enrolled Orgs" ],
+        "summary" : "Get list of stations associated to organizations enrolled to a specific domain",
+        "operationId" : "getStationsForEnrolledOrganizations",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "The enrolled organization on which the stations will be extracted.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "401": {
-            "description": "Unauthorized"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
+        }, {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the stations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/organizations/domains/{domain}": {
-      "get": {
-        "tags": [
-          "Enrolled Orgs"
-        ],
-        "summary": "Get list of organizations enrolled to a specific domain",
-        "operationId": "getEnrolledOrganizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the organizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/domains/{domain}" : {
+      "get" : {
+        "tags" : [ "Enrolled Orgs" ],
+        "summary" : "Get list of organizations enrolled to a specific domain",
+        "operationId" : "getEnrolledOrganizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the organizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "401": {
-            "description": "Unauthorized"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "429": {
-            "description": "Too many requests"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "403": {
-            "description": "Forbidden"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations": {
-      "get": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Get cached authorizations",
-        "operationId": "getAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "formatTTL",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": true
-            }
+    "/cachedauthorizations" : {
+      "get" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Get cached authorizations",
+        "operationId" : "getAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "401": {
-            "description": "Unauthorized"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CachedAuthorizationList"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "formatTTL",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CachedAuthorizationList"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
+      }
+    },
+    "/authorizations/subkey/{subscriptionKey}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by subscription key",
+        "operationId" : "getAuthorizationBySubscriptionKey",
+        "parameters" : [ {
+          "name" : "subscriptionKey",
+          "in" : "path",
+          "description" : "The subscription key related to the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ]
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "Authorization": {
-        "required": [
-          "authorized_entities",
-          "domain",
-          "other_metadata",
-          "owner",
-          "subscription_key"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the saved authorization, automatically generated during creation as UUID."
+  "components" : {
+    "schemas" : {
+      "Authorization" : {
+        "required" : [ "authorized_entities", "domain", "other_metadata", "owner", "subscription_key" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the saved authorization, automatically generated during creation as UUID."
           },
-          "domain": {
-            "type": "string",
-            "description": "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
+          "domain" : {
+            "type" : "string",
+            "description" : "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
           },
-          "description": {
-            "type": "string",
-            "description": "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
+          "description" : {
+            "type" : "string",
+            "description" : "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
           },
-          "owner": {
-            "$ref": "#/components/schemas/AuthorizationOwner"
+          "owner" : {
+            "$ref" : "#/components/schemas/AuthorizationOwner"
           },
-          "authorized_entities": {
-            "type": "array",
-            "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationEntity"
+          "authorized_entities" : {
+            "type" : "array",
+            "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationEntity"
             }
           },
-          "other_metadata": {
-            "type": "array",
-            "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationMetadata"
+          "other_metadata" : {
+            "type" : "array",
+            "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationMetadata"
             }
           },
-          "inserted_at": {
-            "type": "string",
-            "description": "The date of authorization entry. This value is set only in authorization creation operations.",
-            "readOnly": true
+          "inserted_at" : {
+            "type" : "string",
+            "description" : "The date of authorization entry. This value is set only in authorization creation operations.",
+            "readOnly" : true
           },
-          "last_update": {
-            "type": "string",
-            "description": "The date of last authorization update. It is only visible as output in read requests.",
-            "readOnly": true
+          "last_update" : {
+            "type" : "string",
+            "description" : "The date of last authorization update. It is only visible as output in read requests.",
+            "readOnly" : true
           },
-          "last_forced_refresh": {
-            "type": "string",
-            "description": "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
-            "readOnly": true
+          "last_forced_refresh" : {
+            "type" : "string",
+            "description" : "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
+            "readOnly" : true
           }
         },
-        "description": "The list of authorization retrieved from search."
+        "description" : "The list of authorization retrieved from search."
       },
-      "AuthorizationEntity": {
-        "required": [
-          "name",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
+      "AuthorizationEntity" : {
+        "required" : [ "name", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
+        "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
       },
-      "AuthorizationGenericKeyValue": {
-        "required": [
-          "key",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "The key used to reference the metadata into the related map."
+      "AuthorizationGenericKeyValue" : {
+        "required" : [ "key", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "description" : "The key used to reference the metadata into the related map."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "A key-value map that defines the actual content of the metadata to be stored."
+        "description" : "A key-value map that defines the actual content of the metadata to be stored."
       },
-      "AuthorizationMetadata": {
-        "required": [
-          "content",
-          "name",
-          "short_key"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "A description that defines the full name of the metadata."
+      "AuthorizationMetadata" : {
+        "required" : [ "content", "name", "short_key" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "A description that defines the full name of the metadata."
           },
-          "short_key": {
-            "pattern": "_[a-zA-Z0-9]{1,3}",
-            "type": "string",
-            "description": "The key that defines an abbreviation by which it will be identified in cached maps."
+          "short_key" : {
+            "pattern" : "_[a-zA-Z0-9]{1,3}",
+            "type" : "string",
+            "description" : "The key that defines an abbreviation by which it will be identified in cached maps."
           },
-          "content": {
-            "type": "array",
-            "description": "A key-value map that defines the actual content of the metadata to be stored.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationGenericKeyValue"
+          "content" : {
+            "type" : "array",
+            "description" : "A key-value map that defines the actual content of the metadata to be stored.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationGenericKeyValue"
             }
           }
         },
-        "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process."
+        "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process."
       },
-      "AuthorizationOwner": {
-        "required": [
-          "id",
-          "name",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+      "AuthorizationOwner" : {
+        "required" : [ "id", "name", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "name": {
-            "type": "string",
-            "description": "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
           },
-          "type": {
-            "type": "string",
-            "description": "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
-            "enum": [
-              "BROKER",
-              "CI",
-              "OTHER",
-              "PSP"
-            ]
+          "type" : {
+            "type" : "string",
+            "description" : "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
+            "enum" : [ "BROKER", "CI", "OTHER", "PSP" ]
           }
         },
-        "description": "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+        "description" : "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
       },
-      "AuthorizationList": {
-        "required": [
-          "authorizations",
-          "page_info"
-        ],
-        "type": "object",
-        "properties": {
-          "authorizations": {
-            "type": "array",
-            "description": "The list of authorization retrieved from search.",
-            "items": {
-              "$ref": "#/components/schemas/Authorization"
-            }
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "The page number",
-            "format": "int32"
+      "AuthorizationList" : {
+        "required" : [ "authorizations", "page_info" ],
+        "type" : "object",
+        "properties" : {
+          "authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization retrieved from search.",
+            "items" : {
+              "$ref" : "#/components/schemas/Authorization"
+            }
           },
-          "limit": {
-            "type": "integer",
-            "description": "The required maximum number of items per page",
-            "format": "int32"
-          },
-          "items_found": {
-            "type": "integer",
-            "description": "The number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
-          },
-          "total_pages": {
-            "type": "integer",
-            "description": "The total number of pages",
-            "format": "int32"
-          }
-        },
-        "description": "The information related to the paginated results."
-      },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
-          },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
-          },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "EnrolledCreditorInstitution": {
-        "required": [
-          "organization_fiscal_code",
-          "segregation_codes"
-        ],
-        "type": "object",
-        "properties": {
-          "organization_fiscal_code": {
-            "type": "string",
-            "description": "The fiscal code related to the creditor institution."
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "The page number",
+            "format" : "int32"
           },
-          "segregation_codes": {
-            "type": "array",
-            "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
-            "items": {
-              "type": "string",
-              "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain."
+          "limit" : {
+            "type" : "integer",
+            "description" : "The required maximum number of items per page",
+            "format" : "int32"
+          },
+          "items_found" : {
+            "type" : "integer",
+            "description" : "The number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
+          },
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "The total number of pages",
+            "format" : "int32"
+          }
+        },
+        "description" : "The information related to the paginated results."
+      },
+      "EnrolledCreditorInstitution" : {
+        "required" : [ "organization_fiscal_code", "segregation_codes" ],
+        "type" : "object",
+        "properties" : {
+          "organization_fiscal_code" : {
+            "type" : "string",
+            "description" : "The fiscal code related to the creditor institution."
+          },
+          "segregation_codes" : {
+            "type" : "array",
+            "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain."
             }
           }
         },
-        "description": "The list of creditor institution enrolled to the Authorizer service."
+        "description" : "The list of creditor institution enrolled to the Authorizer service."
       },
-      "EnrolledCreditorInstitutionList": {
-        "required": [
-          "creditor_institutions"
-        ],
-        "type": "object",
-        "properties": {
-          "creditor_institutions": {
-            "type": "array",
-            "description": "The list of creditor institution enrolled to the Authorizer service.",
-            "items": {
-              "$ref": "#/components/schemas/EnrolledCreditorInstitution"
+      "EnrolledCreditorInstitutionList" : {
+        "required" : [ "creditor_institutions" ],
+        "type" : "object",
+        "properties" : {
+          "creditor_institutions" : {
+            "type" : "array",
+            "description" : "The list of creditor institution enrolled to the Authorizer service.",
+            "items" : {
+              "$ref" : "#/components/schemas/EnrolledCreditorInstitution"
             }
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           },
-          "dbConnection": {
-            "type": "string"
+          "dbConnection" : {
+            "type" : "string"
           }
         }
       },
-      "CachedAuthorization": {
-        "required": [
-          "ttl"
-        ],
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "The description that is associated with particular noteworthy items to be added to the list of cached information."
+      "CachedAuthorization" : {
+        "required" : [ "ttl" ],
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "description" : "The description that is associated with particular noteworthy items to be added to the list of cached information."
           },
-          "owner": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          "owner" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key associated with the cached authorization."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key associated with the cached authorization."
           },
-          "ttl": {
-            "type": "string",
-            "description": "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
+          "ttl" : {
+            "type" : "string",
+            "description" : "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
           }
         },
-        "description": "The list of authorization cached in Authorizer system."
+        "description" : "The list of authorization cached in Authorizer system."
       },
-      "CachedAuthorizationList": {
-        "required": [
-          "cached_authorizations"
-        ],
-        "type": "object",
-        "properties": {
-          "cached_authorizations": {
-            "type": "array",
-            "description": "The list of authorization cached in Authorizer system.",
-            "items": {
-              "$ref": "#/components/schemas/CachedAuthorization"
+      "CachedAuthorizationList" : {
+        "required" : [ "cached_authorizations" ],
+        "type" : "object",
+        "properties" : {
+          "cached_authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization cached in Authorizer system.",
+            "items" : {
+              "$ref" : "#/components/schemas/CachedAuthorization"
             }
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_core.json
+++ b/openapi/openapi_core.json
@@ -1,879 +1,845 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "@project.artifactId@",
-    "description": "@project.description@",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.1"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "platform-authorizer-config",
+    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.2.1"
   },
-  "servers": [
-    {
-      "url": "http://localhost",
-      "description": "Generated server url"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Cached Authorizations",
-      "description": "Everything about cached authorizations"
-    },
-    {
-      "name": "Authorizations",
-      "description": "Everything about authorizations"
-    }
-  ],
-  "paths": {
-    "/authorizations/{authorizationId}": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization by identifier",
-        "operationId": "getAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Cached Authorizations",
+    "description" : "Everything about cached authorizations"
+  }, {
+    "name" : "Authorizations",
+    "description" : "Everything about authorizations"
+  } ],
+  "paths" : {
+    "/authorizations/{authorizationId}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by identifier",
+        "operationId" : "getAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Update existing authorization",
-        "operationId": "updateAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Update existing authorization",
+        "operationId" : "updateAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429": {
-            "description": "Too many requests"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Delete existing authorization",
-        "operationId": "deleteAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "delete" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Delete existing authorization",
+        "operationId" : "deleteAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK"
+          "200" : {
+            "description" : "OK"
           },
-          "429": {
-            "description": "Too many requests"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations/{domain}/refresh": {
-      "post": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Refresh cached authorizations by domain",
-        "operationId": "refreshCachedAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
+    "/cachedauthorizations/{domain}/refresh" : {
+      "post" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Refresh cached authorizations by domain and owner",
+        "operationId" : "refreshCachedAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {}
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
             }
           },
-          "429": {
-            "description": "Too many requests"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/authorizations": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization list",
-        "operationId": "getAuthorizations_1",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+    "/authorizations" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization list",
+        "operationId" : "getAuthorizations_1",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Create new authorization",
-        "operationId": "createAuthorization",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+      "post" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Create new authorization",
+        "operationId" : "createAuthorization",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        "responses" : {
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations": {
-      "get": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Get cached authorizations",
-        "operationId": "getAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "formatTTL",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": true
-            }
+    "/cachedauthorizations" : {
+      "get" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Get cached authorizations",
+        "operationId" : "getAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CachedAuthorizationList"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "formatTTL",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : true
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CachedAuthorizationList"
                 }
               }
             }
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
+      }
+    },
+    "/authorizations/subkey/{subscriptionKey}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by subscription key",
+        "operationId" : "getAuthorizationBySubscriptionKey",
+        "parameters" : [ {
+          "name" : "subscriptionKey",
+          "in" : "path",
+          "description" : "The subscription key related to the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ]
+        } ],
+        "responses" : {
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
+                }
+              }
+            }
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "Authorization": {
-        "required": [
-          "authorized_entities",
-          "domain",
-          "other_metadata",
-          "owner",
-          "subscription_key"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the saved authorization, automatically generated during creation as UUID."
+  "components" : {
+    "schemas" : {
+      "Authorization" : {
+        "required" : [ "authorized_entities", "domain", "other_metadata", "owner", "subscription_key" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the saved authorization, automatically generated during creation as UUID."
           },
-          "domain": {
-            "type": "string",
-            "description": "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
+          "domain" : {
+            "type" : "string",
+            "description" : "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
           },
-          "description": {
-            "type": "string",
-            "description": "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
+          "description" : {
+            "type" : "string",
+            "description" : "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
           },
-          "owner": {
-            "$ref": "#/components/schemas/AuthorizationOwner"
+          "owner" : {
+            "$ref" : "#/components/schemas/AuthorizationOwner"
           },
-          "authorized_entities": {
-            "type": "array",
-            "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationEntity"
+          "authorized_entities" : {
+            "type" : "array",
+            "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationEntity"
             }
           },
-          "other_metadata": {
-            "type": "array",
-            "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationMetadata"
+          "other_metadata" : {
+            "type" : "array",
+            "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationMetadata"
             }
           },
-          "inserted_at": {
-            "type": "string",
-            "description": "The date of authorization entry. This value is set only in authorization creation operations.",
-            "readOnly": true
+          "inserted_at" : {
+            "type" : "string",
+            "description" : "The date of authorization entry. This value is set only in authorization creation operations.",
+            "readOnly" : true
           },
-          "last_update": {
-            "type": "string",
-            "description": "The date of last authorization update. It is only visible as output in read requests.",
-            "readOnly": true
+          "last_update" : {
+            "type" : "string",
+            "description" : "The date of last authorization update. It is only visible as output in read requests.",
+            "readOnly" : true
           },
-          "last_forced_refresh": {
-            "type": "string",
-            "description": "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
-            "readOnly": true
+          "last_forced_refresh" : {
+            "type" : "string",
+            "description" : "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
+            "readOnly" : true
           }
         },
-        "description": "The list of authorization retrieved from search."
+        "description" : "The list of authorization retrieved from search."
       },
-      "AuthorizationEntity": {
-        "required": [
-          "name",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
+      "AuthorizationEntity" : {
+        "required" : [ "name", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
+        "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
       },
-      "AuthorizationGenericKeyValue": {
-        "required": [
-          "key",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "The key used to reference the metadata into the related map."
+      "AuthorizationGenericKeyValue" : {
+        "required" : [ "key", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "description" : "The key used to reference the metadata into the related map."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "A key-value map that defines the actual content of the metadata to be stored."
+        "description" : "A key-value map that defines the actual content of the metadata to be stored."
       },
-      "AuthorizationMetadata": {
-        "required": [
-          "content",
-          "name",
-          "short_key"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "A description that defines the full name of the metadata."
+      "AuthorizationMetadata" : {
+        "required" : [ "content", "name", "short_key" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "A description that defines the full name of the metadata."
           },
-          "short_key": {
-            "pattern": "_[a-zA-Z0-9]{1,3}",
-            "type": "string",
-            "description": "The key that defines an abbreviation by which it will be identified in cached maps."
+          "short_key" : {
+            "pattern" : "_[a-zA-Z0-9]{1,3}",
+            "type" : "string",
+            "description" : "The key that defines an abbreviation by which it will be identified in cached maps."
           },
-          "content": {
-            "type": "array",
-            "description": "A key-value map that defines the actual content of the metadata to be stored.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationGenericKeyValue"
+          "content" : {
+            "type" : "array",
+            "description" : "A key-value map that defines the actual content of the metadata to be stored.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationGenericKeyValue"
             }
           }
         },
-        "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process."
+        "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process."
       },
-      "AuthorizationOwner": {
-        "required": [
-          "id",
-          "name",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+      "AuthorizationOwner" : {
+        "required" : [ "id", "name", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "name": {
-            "type": "string",
-            "description": "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
           },
-          "type": {
-            "type": "string",
-            "description": "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
-            "enum": [
-              "BROKER",
-              "CI",
-              "OTHER",
-              "PSP"
-            ]
+          "type" : {
+            "type" : "string",
+            "description" : "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
+            "enum" : [ "BROKER", "CI", "OTHER", "PSP" ]
           }
         },
-        "description": "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+        "description" : "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "AuthorizationList": {
-        "required": [
-          "authorizations",
-          "page_info"
-        ],
-        "type": "object",
-        "properties": {
-          "authorizations": {
-            "type": "array",
-            "description": "The list of authorization retrieved from search.",
-            "items": {
-              "$ref": "#/components/schemas/Authorization"
+      "AuthorizationList" : {
+        "required" : [ "authorizations", "page_info" ],
+        "type" : "object",
+        "properties" : {
+          "authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization retrieved from search.",
+            "items" : {
+              "$ref" : "#/components/schemas/Authorization"
             }
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "The page number",
-            "format": "int32"
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "The page number",
+            "format" : "int32"
           },
-          "limit": {
-            "type": "integer",
-            "description": "The required maximum number of items per page",
-            "format": "int32"
+          "limit" : {
+            "type" : "integer",
+            "description" : "The required maximum number of items per page",
+            "format" : "int32"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "The number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "items_found" : {
+            "type" : "integer",
+            "description" : "The number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "The total number of pages",
-            "format": "int32"
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "The total number of pages",
+            "format" : "int32"
           }
         },
-        "description": "The information related to the paginated results."
+        "description" : "The information related to the paginated results."
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           },
-          "dbConnection": {
-            "type": "string"
+          "dbConnection" : {
+            "type" : "string"
           }
         }
       },
-      "CachedAuthorization": {
-        "required": [
-          "ttl"
-        ],
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "The description that is associated with particular noteworthy items to be added to the list of cached information."
+      "CachedAuthorization" : {
+        "required" : [ "ttl" ],
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "description" : "The description that is associated with particular noteworthy items to be added to the list of cached information."
           },
-          "owner": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          "owner" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key associated with the cached authorization."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key associated with the cached authorization."
           },
-          "ttl": {
-            "type": "string",
-            "description": "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
+          "ttl" : {
+            "type" : "string",
+            "description" : "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
           }
         },
-        "description": "The list of authorization cached in Authorizer system."
+        "description" : "The list of authorization cached in Authorizer system."
       },
-      "CachedAuthorizationList": {
-        "required": [
-          "cached_authorizations"
-        ],
-        "type": "object",
-        "properties": {
-          "cached_authorizations": {
-            "type": "array",
-            "description": "The list of authorization cached in Authorizer system.",
-            "items": {
-              "$ref": "#/components/schemas/CachedAuthorization"
+      "CachedAuthorizationList" : {
+        "required" : [ "cached_authorizations" ],
+        "type" : "object",
+        "properties" : {
+          "cached_authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization cached in Authorizer system.",
+            "items" : {
+              "$ref" : "#/components/schemas/CachedAuthorization"
             }
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/src/main/java/it/gov/pagopa/authorizer/config/controller/AuthorizationController.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/controller/AuthorizationController.java
@@ -108,6 +108,34 @@ public class AuthorizationController {
   }
 
   /**
+   * GET /{authorizationId} : Get authorization by subscription key
+   *
+   * @param subscriptionKey The subscription key related to the stored authorization.
+   * @return OK (status code 200) or Not Found (status code 404) or Too many request (status code 429) or Service unavailable/error (status code 500)
+   */
+  @Operation(
+      summary = "Get authorization by subscription key",
+      security = {
+          @SecurityRequirement(name = "ApiKey")
+      },
+      tags = { "Authorizations" })
+  @ApiResponses(
+      value = {
+          @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = AuthorizationList.class))),
+          @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
+          @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
+          @ApiResponse(responseCode = "404", description = "Not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class))),
+          @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
+          @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
+      })
+  @GetMapping(value = "/subkey/{subscriptionKey}", produces = {MediaType.APPLICATION_JSON_VALUE})
+  public ResponseEntity<Authorization> getAuthorizationBySubscriptionKey(
+      @Parameter(description = "The subscription key related to the stored authorization.", required = true)
+      @PathVariable("subscriptionKey") String subscriptionKey) {
+    return ResponseEntity.ok(authorizationService.getAuthorizationBySubscriptionKey(subscriptionKey));
+  }
+
+  /**
    * POST / : Create new authorization
    *
    * @param authorization The authorization content to be created.

--- a/src/main/java/it/gov/pagopa/authorizer/config/controller/CachedAuthorizationController.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/controller/CachedAuthorizationController.java
@@ -65,14 +65,14 @@ public class CachedAuthorizationController {
 
 
   /**
-   * POST /{domain}/refresh : Refresh cached authorizations by domain
+   * POST /{domain}/refresh : Refresh cached authorizations by domain and owner
    *
    * @param domain  The domain on which the authorizations will be filtered.
    * @param ownerId The identifier of the authorizations' owner.
    * @return OK (status code 200) or Bad Request (status code 400) or Conflict (status code 409) or Too many request (status code 429) or Service unavailable (status code 500)
    */
   @Operation(
-      summary = "Refresh cached authorizations by domain",
+      summary = "Refresh cached authorizations by domain and owner",
       security = {
           @SecurityRequirement(name = "ApiKey")
       },
@@ -90,7 +90,7 @@ public class CachedAuthorizationController {
       @Parameter(description = "The domain on which the authorizations will be filtered.", required = true)
       @NotBlank @PathVariable("domain") String domain,
       @Parameter(description = "The identifier of the authorizations' owner.")
-      @RequestParam(value = "ownerId", required = false) String ownerId) {
+      @NotBlank @RequestParam(value = "ownerId", required = false) String ownerId) {
     authorizationService.refreshCachedAuthorizations(domain, ownerId);
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/it/gov/pagopa/authorizer/config/controller/CachedAuthorizationController.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/controller/CachedAuthorizationController.java
@@ -89,8 +89,8 @@ public class CachedAuthorizationController {
   public ResponseEntity<Authorization> refreshCachedAuthorizations(
       @Parameter(description = "The domain on which the authorizations will be filtered.", required = true)
       @NotBlank @PathVariable("domain") String domain,
-      @Parameter(description = "The identifier of the authorizations' owner.")
-      @NotBlank @RequestParam(value = "ownerId", required = false) String ownerId) {
+      @Parameter(description = "The identifier of the authorizations' owner.", required = true)
+      @NotBlank @RequestParam(value = "ownerId") String ownerId) {
     authorizationService.refreshCachedAuthorizations(domain, ownerId);
     return ResponseEntity.ok().build();
   }

--- a/src/main/java/it/gov/pagopa/authorizer/config/exception/AppError.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/exception/AppError.java
@@ -17,6 +17,8 @@ public enum AppError {
 
   NOT_FOUND_NO_VALID_AUTHORIZATION(HttpStatus.NOT_FOUND, "Authorization not found", "No authorization with id [%s] was found."),
 
+  NOT_FOUND_NO_VALID_AUTHORIZATION_WITH_SUBKEY(HttpStatus.NOT_FOUND, "Authorization not found", "No authorization with subkey [%s] was found."),
+
   NOT_FOUND_CI_NOT_ENROLLED(HttpStatus.NOT_FOUND, "Invalid creditor institution", "No creditor institution with fiscal code [%s] is enrolled to domain [%s]."),
 
   NOT_FOUND_NO_VALID_STATION(HttpStatus.NOT_FOUND, "Invalid station", "No creditor institution with fiscal code [%s] has valid registered stations for domain [%s]."),
@@ -31,7 +33,9 @@ public enum AppError {
 
   INTERNAL_SERVER_ERROR_DELETE(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while deleting the authorization."),
 
-  INTERNAL_SERVER_ERROR_REFRESH(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while refreshing the cached authorizations.");
+  INTERNAL_SERVER_ERROR_REFRESH(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while refreshing the cached authorizations."),
+
+  INTERNAL_SERVER_ERROR_MULTIPLE_AUTHORIZATION_WITH_SAME_SUBKEY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "There are multiple authorization with the same subscription key [%s]. Please, check if they are correct.");
 
   public final HttpStatus httpStatus;
   public final String title;

--- a/src/main/java/it/gov/pagopa/authorizer/config/repository/AuthorizationRepository.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/repository/AuthorizationRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface AuthorizationRepository extends CosmosRepository<SubscriptionKeyDomain, String> {
@@ -19,6 +20,8 @@ public interface AuthorizationRepository extends CosmosRepository<SubscriptionKe
   List<SubscriptionKeyDomain> findByDomainAndOwnerId(@Param("domain") String domain, @Param("ownerId") String ownerId);
 
   List<SubscriptionKeyDomain> findByDomain(String domain);
+
+  Optional<SubscriptionKeyDomain> findBySubkey(String subkey);
 
   Page<SubscriptionKeyDomain> findByDomainAndOwnerId(String domain, String ownerId, Pageable pageable);
 

--- a/src/test/java/it/gov/pagopa/authorizer/config/controller/AuthorizationControllerTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/controller/AuthorizationControllerTest.java
@@ -77,6 +77,45 @@ class AuthorizationControllerTest {
   }
 
   @Test
+  void getAuthorizationBySubkey_200() throws Exception {
+    String subkey = "some-subkey";
+    String url = String.format("/authorizations/subkey/%s", subkey);
+    // mocking invocation
+    when(authorizationService.getAuthorizationBySubscriptionKey(anyString()))
+            .thenReturn(TestUtil.getAuthorization(0, subkey, "some-domain", "some-owner"));
+    // executing API call
+    mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void getAuthorizationBySubkey_404() throws Exception {
+    String subkey = "some-subkey";
+    String url = String.format("/authorizations/subkey/%s", subkey);
+    // mocking invocation
+    when(authorizationService.getAuthorizationBySubscriptionKey(anyString()))
+            .thenThrow(new AppException(AppError.NOT_FOUND_NO_VALID_AUTHORIZATION_WITH_SUBKEY, subkey));
+    // executing API call
+    mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void getAuthorizationBySubkey_500() throws Exception {
+    String subkey = "some-subkey";
+    String url = String.format("/authorizations/subkey/%s", subkey);
+    // mocking invocation
+    when(authorizationService.getAuthorizationBySubscriptionKey(anyString()))
+            .thenThrow(new AppException(AppError.INTERNAL_SERVER_ERROR_MULTIPLE_AUTHORIZATION_WITH_SAME_SUBKEY, subkey));
+    // executing API call
+    mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
   void createAuthorization_200() throws Exception {
     String id = "some-uuid";
     String url = "/authorizations/";

--- a/src/test/java/it/gov/pagopa/authorizer/config/controller/CachedAuthorizationControllerTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/controller/CachedAuthorizationControllerTest.java
@@ -52,13 +52,9 @@ class CachedAuthorizationControllerTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 
-    @ParameterizedTest
-    @CsvSource({
-            "fakedomain,,",
-            "fakedomain,77777777777",
-    })
-    void refreshCachedAuthorizations_200(String domain, String ownerId) throws Exception {
-        String url = String.format("/cachedauthorizations/%s/refresh?ownerId=%s", domain, ownerId == null ? "" : ownerId);
+    @Test
+    void refreshCachedAuthorizations_200() throws Exception {
+        String url = String.format("/cachedauthorizations/%s/refresh?ownerId=%s", "fakedomain", "77777777777");
         // mocking invocation
         doNothing().when(authorizationService).refreshCachedAuthorizations(anyString(), anyString());
         // executing API call

--- a/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import javax.persistence.NonUniqueResultException;
 import java.util.List;
 import java.util.Optional;
 
@@ -99,6 +100,48 @@ class AuthorizationServiceTest {
         // executing assertion check
         assertEquals(AppError.NOT_FOUND_NO_VALID_AUTHORIZATION.httpStatus, exception.getHttpStatus());
         assertEquals(AppError.NOT_FOUND_NO_VALID_AUTHORIZATION.title, exception.getTitle());
+    }
+
+    @Test
+    void getAuthorizationBySubscriptionKey_200() {
+        // initialize objects
+        String subkey = "fake_subkey";
+        // Mocking objects
+        SubscriptionKeyDomain subscriptionKeyDomain = TestUtil.getSubscriptionKeyDomain(1, subkey, "gpd", "fakedomain");
+        subscriptionKeyDomain.setSubkey(subkey);
+        when(authorizationRepository.findBySubkey(subkey)).thenReturn(Optional.ofNullable(subscriptionKeyDomain));
+        // executing logic
+        Authorization result = authorizationService.getAuthorizationBySubscriptionKey(subkey);
+        // executing assertion check
+        assertNotNull(result);
+        assertEquals(subkey, result.getSubscriptionKey());
+        assertTrue(result.getAuthorizedEntities().size() > 0);
+    }
+
+    @Test
+    void getAuthorizationBySubscriptionKey_404() {
+        // initialize objects
+        String subkey = "fake_subkey";
+        // Mocking objects
+        when(authorizationRepository.findBySubkey(subkey)).thenReturn(Optional.empty());
+        // executing logic
+        AppException exception = assertThrows(AppException.class, () -> authorizationService.getAuthorizationBySubscriptionKey(subkey));
+        // executing assertion check
+        assertEquals(AppError.NOT_FOUND_NO_VALID_AUTHORIZATION_WITH_SUBKEY.httpStatus, exception.getHttpStatus());
+        assertEquals(AppError.NOT_FOUND_NO_VALID_AUTHORIZATION_WITH_SUBKEY.title, exception.getTitle());
+    }
+
+    @Test
+    void getAuthorizationBySubscriptionKey_500() {
+        // initialize objects
+        String subkey = "fake_subkey";
+        // Mocking objects
+        when(authorizationRepository.findBySubkey(subkey)).thenThrow(NonUniqueResultException.class);
+        // executing logic
+        AppException exception = assertThrows(AppException.class, () -> authorizationService.getAuthorizationBySubscriptionKey(subkey));
+        // executing assertion check
+        assertEquals(AppError.INTERNAL_SERVER_ERROR_MULTIPLE_AUTHORIZATION_WITH_SAME_SUBKEY.httpStatus, exception.getHttpStatus());
+        assertEquals(AppError.INTERNAL_SERVER_ERROR_MULTIPLE_AUTHORIZATION_WITH_SAME_SUBKEY.title, exception.getTitle());
     }
 
     @Test

--- a/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.authorizer.config.service;
 
+import com.azure.spring.data.cosmos.exception.CosmosAccessException;
 import it.gov.pagopa.authorizer.config.Application;
 import it.gov.pagopa.authorizer.config.entity.SubscriptionKeyDomain;
 import it.gov.pagopa.authorizer.config.exception.AppError;
@@ -136,7 +137,7 @@ class AuthorizationServiceTest {
         // initialize objects
         String subkey = "fake_subkey";
         // Mocking objects
-        when(authorizationRepository.findBySubkey(subkey)).thenThrow(NonUniqueResultException.class);
+        when(authorizationRepository.findBySubkey(subkey)).thenThrow(CosmosAccessException.class);
         // executing logic
         AppException exception = assertThrows(AppException.class, () -> authorizationService.getAuthorizationBySubscriptionKey(subkey));
         // executing assertion check


### PR DESCRIPTION
This PR contains several changes made on two APIs. The first change is made on `authorization/{domain}/refresh` API in order to set the `ownerId` parameter as mandatory. The other impacted API is `authorization/subkey/{subscriptionKey}` and it is defined as new API that provide a fast search by subscription key.

#### List of Changes
- Added new API for searching authorization by subscription key
- Updated force refresh's API imposing `ownerId` as mandatory parameter
- Updated OpenAPI and JUnit tests

#### Motivation and Context
The change on existing API is made in order to resolve a known bug on `cache-remove-value` instruction for APIM policy.

#### How Has This Been Tested?
Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.