### PR TITLE
feat: [PAGOPA-3258] Introducing "authorized entities" retrieve API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ hs_err_pid*
 # Helm
 /helm/charts/*
 **/.terraform/
+/.run/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-platform-authorizer-config
 description: Microservice that provides a set of APIs to manage authorization records for the Authorizer system.
 type: application
-version: 0.43.0
-appVersion: 0.2.14
+version: 0.44.0
+appVersion: 0.2.14-1-PAGOPA-3258
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-platform-authorizer-config
-    tag: "0.2.14"
+    tag: "0.2.14-1-PAGOPA-3258"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -79,6 +79,9 @@ microservice-chart:
     CLIENT_CONNECTION_TIMEOUT: "10000"
     APICONFIG_SELFCARE_INTEGRATION_PATH: "https://api.dev.platform.pagopa.it/apiconfig-selfcare-integration/v1"
     CORS_CONFIGURATION: '{"origins": ["*"], "methods": ["*"]}'
+    CACHE_AUTHORIZED_ENTITIES_TTL: "86400"
+    SCHEDULER_ENABLED: "true"
+    AUTOCACHE_SCHEDULE_CRON: "0 0 */12 * * *"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-platform-authorizer-config
-    tag: "0.2.14"
+    tag: "0.2.14-1-PAGOPA-3258"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -81,6 +81,9 @@ microservice-chart:
     CORS_CONFIGURATION: '{"origins": ["*"], "methods": ["*"]}'
     CONFIGURATION_LIMIT: "20"
     CONFIGURATION_OFFSET: "0"
+    CACHE_AUTHORIZED_ENTITIES_TTL: "86400"
+    SCHEDULER_ENABLED: "true"
+    AUTOCACHE_SCHEDULE_CRON: "0 0 */4 * * *"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -79,6 +79,9 @@ microservice-chart:
     CLIENT_CONNECTION_TIMEOUT: "10000"
     APICONFIG_SELFCARE_INTEGRATION_PATH: "https://api.uat.platform.pagopa.it/apiconfig-selfcare-integration/v1"
     CORS_CONFIGURATION: '{"origins": ["*"], "methods": ["*"]}'
+    CACHE_AUTHORIZED_ENTITIES_TTL: "86400"
+    SCHEDULER_ENABLED: "true"
+    AUTOCACHE_SCHEDULE_CRON: "0 0 */12 * * *"
   envFieldRef:
     APP_NAME: "metadata.labels['app.kubernetes.io/instance']"
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-platform-authorizer-config
-    tag: "0.2.14"
+    tag: "0.2.14-1-PAGOPA-3258"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,1127 +1,1054 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "platform-authorizer-config",
-    "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.14"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "platform-authorizer-config",
+    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.2.14"
   },
-  "servers": [
-    {
-      "url": "http://localhost",
-      "description": "Generated server url"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Enrolled Orgs",
-      "description": "Everything about enrolled organizations"
-    },
-    {
-      "name": "Cached Authorizations",
-      "description": "Everything about cached authorizations"
-    },
-    {
-      "name": "Authorizations",
-      "description": "Everything about authorizations"
-    }
-  ],
-  "paths": {
-    "/authorizations/{authorizationId}": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization by identifier",
-        "operationId": "getAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Enrolled Orgs",
+    "description" : "Everything about enrolled organizations"
+  }, {
+    "name" : "Cached Authorizations",
+    "description" : "Everything about cached authorizations"
+  }, {
+    "name" : "Authorizations",
+    "description" : "Everything about authorizations"
+  } ],
+  "paths" : {
+    "/authorizations/{authorizationId}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by identifier",
+        "operationId" : "getAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Update existing authorization",
-        "operationId": "updateAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Update existing authorization",
+        "operationId" : "updateAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Delete existing authorization",
-        "operationId": "deleteAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customKeyFormat",
-            "in": "query",
-            "description": "Custom key for cache used by APIM",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": ""
-            }
+      "delete" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Delete existing authorization",
+        "operationId" : "deleteAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "customKeyFormat",
+          "in" : "query",
+          "description" : "Custom key for cache used by APIM",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
+          "200" : {
+            "description" : "OK"
           },
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations/{domain}/refresh": {
-      "post": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Refresh cached authorizations by domain and owner",
-        "operationId": "refreshCachedAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
+    "/cachedauthorizations/{domain}/refresh" : {
+      "post" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Refresh cached authorizations by domain and owner",
+        "operationId" : "refreshCachedAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {}
-            }
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/authorizations": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization list",
-        "operationId": "getAuthorizations_1",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+    "/authorizations" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization list",
+        "operationId" : "getAuthorizations_1",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "403": {
-            "description": "Forbidden"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Create new authorization",
-        "operationId": "createAuthorization",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+      "post" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Create new authorization",
+        "operationId" : "createAuthorization",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/organizations/{organizationfiscalcode}/domains/{domain}": {
-      "get": {
-        "tags": [
-          "Enrolled Orgs"
-        ],
-        "summary": "Get list of stations associated to organizations enrolled to a specific domain",
-        "operationId": "getStationsForEnrolledOrganizations",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "The enrolled organization on which the stations will be extracted.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the stations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/{organizationfiscalcode}/domains/{domain}" : {
+      "get" : {
+        "tags" : [ "Enrolled Orgs" ],
+        "summary" : "Get list of stations associated to organizations enrolled to a specific domain",
+        "operationId" : "getStationsForEnrolledOrganizations",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "The enrolled organization on which the stations will be extracted.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the stations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/organizations/domains/{domain}": {
-      "get": {
-        "tags": [
-          "Enrolled Orgs"
-        ],
-        "summary": "Get list of organizations enrolled to a specific domain",
-        "operationId": "getEnrolledOrganizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the organizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/domains/{domain}" : {
+      "get" : {
+        "tags" : [ "Enrolled Orgs" ],
+        "summary" : "Get list of organizations enrolled to a specific domain",
+        "operationId" : "getEnrolledOrganizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the organizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations": {
-      "get": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Get cached authorizations",
-        "operationId": "getAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "formatTTL",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "name": "customKeyFormat",
-            "in": "query",
-            "description": "Custom key for cache used by APIM",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": ""
-            }
+    "/cachedauthorizations" : {
+      "get" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Get cached authorizations",
+        "operationId" : "getAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "formatTTL",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : true
+          }
+        }, {
+          "name" : "customKeyFormat",
+          "in" : "query",
+          "description" : "Custom key for cache used by APIM",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CachedAuthorizationList"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CachedAuthorizationList"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/authorizations/subkey/{subscriptionKey}": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization by subscription key",
-        "operationId": "getAuthorizationBySubscriptionKey",
-        "parameters": [
-          {
-            "name": "subscriptionKey",
-            "in": "path",
-            "description": "The subscription key related to the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/authorizations/subkey/{subscriptionKey}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by subscription key",
+        "operationId" : "getAuthorizationBySubscriptionKey",
+        "parameters" : [ {
+          "name" : "subscriptionKey",
+          "in" : "path",
+          "description" : "The subscription key related to the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
+      }
+    },
+    "/authorizations/domains/{domain}/authorizedentities" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorized entities by domain",
+        "operationId" : "getAuthorizedEntitiesByDomain",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "Authorization": {
-        "required": [
-          "authorized_entities",
-          "domain",
-          "other_metadata",
-          "owner",
-          "subscription_key"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the saved authorization, automatically generated during creation as UUID."
+  "components" : {
+    "schemas" : {
+      "Authorization" : {
+        "required" : [ "authorized_entities", "domain", "other_metadata", "owner", "subscription_key" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the saved authorization, automatically generated during creation as UUID."
           },
-          "domain": {
-            "type": "string",
-            "description": "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
+          "domain" : {
+            "type" : "string",
+            "description" : "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
           },
-          "description": {
-            "type": "string",
-            "description": "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
+          "description" : {
+            "type" : "string",
+            "description" : "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
           },
-          "owner": {
-            "$ref": "#/components/schemas/AuthorizationOwner"
+          "owner" : {
+            "$ref" : "#/components/schemas/AuthorizationOwner"
           },
-          "authorized_entities": {
-            "type": "array",
-            "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationEntity"
+          "authorized_entities" : {
+            "type" : "array",
+            "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationEntity"
             }
           },
-          "other_metadata": {
-            "type": "array",
-            "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationMetadata"
+          "other_metadata" : {
+            "type" : "array",
+            "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationMetadata"
             }
           },
-          "inserted_at": {
-            "type": "string",
-            "description": "The date of authorization entry. This value is set only in authorization creation operations.",
-            "readOnly": true
+          "inserted_at" : {
+            "type" : "string",
+            "description" : "The date of authorization entry. This value is set only in authorization creation operations.",
+            "readOnly" : true
           },
-          "last_update": {
-            "type": "string",
-            "description": "The date of last authorization update. It is only visible as output in read requests.",
-            "readOnly": true
+          "last_update" : {
+            "type" : "string",
+            "description" : "The date of last authorization update. It is only visible as output in read requests.",
+            "readOnly" : true
           },
-          "last_forced_refresh": {
-            "type": "string",
-            "description": "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
-            "readOnly": true
+          "last_forced_refresh" : {
+            "type" : "string",
+            "description" : "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
+            "readOnly" : true
           }
         },
-        "description": "The list of authorization retrieved from search."
+        "description" : "The list of authorization retrieved from search."
       },
-      "AuthorizationEntity": {
-        "required": [
-          "name",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
+      "AuthorizationEntity" : {
+        "required" : [ "name", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
+        "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
       },
-      "AuthorizationGenericKeyValue": {
-        "required": [
-          "key",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "The key used to reference the metadata into the related map."
+      "AuthorizationGenericKeyValue" : {
+        "required" : [ "key", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "description" : "The key used to reference the metadata into the related map."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "A key-value map that defines the actual content of the metadata to be stored."
+        "description" : "A key-value map that defines the actual content of the metadata to be stored."
       },
-      "AuthorizationMetadata": {
-        "required": [
-          "content",
-          "name",
-          "short_key"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "A description that defines the full name of the metadata."
+      "AuthorizationMetadata" : {
+        "required" : [ "content", "name", "short_key" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "A description that defines the full name of the metadata."
           },
-          "short_key": {
-            "pattern": "_[a-zA-Z0-9]{1,3}",
-            "type": "string",
-            "description": "The key that defines an abbreviation by which it will be identified in cached maps."
+          "short_key" : {
+            "pattern" : "_[a-zA-Z0-9]{1,3}",
+            "type" : "string",
+            "description" : "The key that defines an abbreviation by which it will be identified in cached maps."
           },
-          "content": {
-            "type": "array",
-            "description": "A key-value map that defines the actual content of the metadata to be stored.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationGenericKeyValue"
+          "content" : {
+            "type" : "array",
+            "description" : "A key-value map that defines the actual content of the metadata to be stored.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationGenericKeyValue"
             }
           }
         },
-        "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process."
+        "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process."
       },
-      "AuthorizationOwner": {
-        "required": [
-          "id",
-          "name",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+      "AuthorizationOwner" : {
+        "required" : [ "id", "name", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "name": {
-            "type": "string",
-            "description": "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
           },
-          "type": {
-            "type": "string",
-            "description": "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
-            "enum": [
-              "BROKER",
-              "CI",
-              "OTHER",
-              "PSP"
-            ]
+          "type" : {
+            "type" : "string",
+            "description" : "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
+            "enum" : [ "BROKER", "CI", "OTHER", "PSP" ]
           }
         },
-        "description": "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+        "description" : "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "AuthorizationList" : {
+        "required" : [ "authorizations", "page_info" ],
+        "type" : "object",
+        "properties" : {
+          "authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization retrieved from search.",
+            "items" : {
+              "$ref" : "#/components/schemas/Authorization"
+            }
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
-          },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "AuthorizationList": {
-        "required": [
-          "authorizations",
-          "page_info"
-        ],
-        "type": "object",
-        "properties": {
-          "authorizations": {
-            "type": "array",
-            "description": "The list of authorization retrieved from search.",
-            "items": {
-              "$ref": "#/components/schemas/Authorization"
-            }
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "The page number",
+            "format" : "int32"
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "limit" : {
+            "type" : "integer",
+            "description" : "The required maximum number of items per page",
+            "format" : "int32"
+          },
+          "items_found" : {
+            "type" : "integer",
+            "description" : "The number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
+          },
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "The total number of pages",
+            "format" : "int32"
+          }
+        },
+        "description" : "The information related to the paginated results."
+      },
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+          },
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "The page number",
-            "format": "int32"
+      "EnrolledCreditorInstitution" : {
+        "required" : [ "organization_fiscal_code", "segregation_codes" ],
+        "type" : "object",
+        "properties" : {
+          "organization_fiscal_code" : {
+            "type" : "string",
+            "description" : "The fiscal code related to the creditor institution."
           },
-          "limit": {
-            "type": "integer",
-            "description": "The required maximum number of items per page",
-            "format": "int32"
-          },
-          "items_found": {
-            "type": "integer",
-            "description": "The number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
-          },
-          "total_pages": {
-            "type": "integer",
-            "description": "The total number of pages",
-            "format": "int32"
-          }
-        },
-        "description": "The information related to the paginated results."
-      },
-      "EnrolledCreditorInstitution": {
-        "required": [
-          "organization_fiscal_code",
-          "segregation_codes"
-        ],
-        "type": "object",
-        "properties": {
-          "organization_fiscal_code": {
-            "type": "string",
-            "description": "The fiscal code related to the creditor institution."
-          },
-          "segregation_codes": {
-            "type": "array",
-            "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
-            "items": {
-              "type": "string",
-              "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain."
+          "segregation_codes" : {
+            "type" : "array",
+            "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain."
             }
           }
         },
-        "description": "The list of creditor institution enrolled to the Authorizer service."
+        "description" : "The list of creditor institution enrolled to the Authorizer service."
       },
-      "EnrolledCreditorInstitutionList": {
-        "required": [
-          "creditor_institutions"
-        ],
-        "type": "object",
-        "properties": {
-          "creditor_institutions": {
-            "type": "array",
-            "description": "The list of creditor institution enrolled to the Authorizer service.",
-            "items": {
-              "$ref": "#/components/schemas/EnrolledCreditorInstitution"
+      "EnrolledCreditorInstitutionList" : {
+        "required" : [ "creditor_institutions" ],
+        "type" : "object",
+        "properties" : {
+          "creditor_institutions" : {
+            "type" : "array",
+            "description" : "The list of creditor institution enrolled to the Authorizer service.",
+            "items" : {
+              "$ref" : "#/components/schemas/EnrolledCreditorInstitution"
             }
           }
         }
       },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
+          "version" : {
+            "type" : "string"
           },
-          "environment": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           },
-          "dbConnection": {
-            "type": "string"
+          "dbConnection" : {
+            "type" : "string"
           }
         }
       },
-      "CachedAuthorization": {
-        "required": [
-          "ttl"
-        ],
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "The description that is associated with particular noteworthy items to be added to the list of cached information."
+      "CachedAuthorization" : {
+        "required" : [ "ttl" ],
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "description" : "The description that is associated with particular noteworthy items to be added to the list of cached information."
           },
-          "owner": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          "owner" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key associated with the cached authorization."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key associated with the cached authorization."
           },
-          "ttl": {
-            "type": "string",
-            "description": "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
+          "ttl" : {
+            "type" : "string",
+            "description" : "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
           }
         },
-        "description": "The list of authorization cached in Authorizer system."
+        "description" : "The list of authorization cached in Authorizer system."
       },
-      "CachedAuthorizationList": {
-        "required": [
-          "cached_authorizations"
-        ],
-        "type": "object",
-        "properties": {
-          "cached_authorizations": {
-            "type": "array",
-            "description": "The list of authorization cached in Authorizer system.",
-            "items": {
-              "$ref": "#/components/schemas/CachedAuthorization"
+      "CachedAuthorizationList" : {
+        "required" : [ "cached_authorizations" ],
+        "type" : "object",
+        "properties" : {
+          "cached_authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization cached in Authorizer system.",
+            "items" : {
+              "$ref" : "#/components/schemas/CachedAuthorization"
             }
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1,1054 +1,1181 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "platform-authorizer-config",
-    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.2.14"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "platform-authorizer-config",
+    "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.2.14-1-PAGOPA-3258"
   },
-  "servers" : [ {
-    "url" : "http://localhost",
-    "description" : "Generated server url"
-  } ],
-  "tags" : [ {
-    "name" : "Enrolled Orgs",
-    "description" : "Everything about enrolled organizations"
-  }, {
-    "name" : "Cached Authorizations",
-    "description" : "Everything about cached authorizations"
-  }, {
-    "name" : "Authorizations",
-    "description" : "Everything about authorizations"
-  } ],
-  "paths" : {
-    "/authorizations/{authorizationId}" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorization by identifier",
-        "operationId" : "getAuthorization",
-        "parameters" : [ {
-          "name" : "authorizationId",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Enrolled Orgs",
+      "description": "Everything about enrolled organizations"
+    },
+    {
+      "name": "Cached Authorizations",
+      "description": "Everything about cached authorizations"
+    },
+    {
+      "name": "Authorizations",
+      "description": "Everything about authorizations"
+    }
+  ],
+  "paths": {
+    "/authorizations/{authorizationId}": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorization by identifier",
+        "operationId": "getAuthorization",
+        "parameters": [
+          {
+            "name": "authorizationId",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Update existing authorization",
-        "operationId" : "updateAuthorization",
-        "parameters" : [ {
-          "name" : "authorizationId",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/Authorization"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "429" : {
-            "description" : "Too many requests"
-          },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
+      "put": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Update existing authorization",
+        "operationId": "updateAuthorization",
+        "parameters": [
+          {
+            "name": "authorizationId",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Authorization"
+              }
+            }
+          },
+          "required": true
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Delete existing authorization",
-        "operationId" : "deleteAuthorization",
-        "parameters" : [ {
-          "name" : "authorizationId",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "customKeyFormat",
-          "in" : "query",
-          "description" : "Custom key for cache used by APIM",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+      "delete": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Delete existing authorization",
+        "operationId": "deleteAuthorization",
+        "parameters": [
+          {
+            "name": "authorizationId",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "customKeyFormat",
+            "in": "query",
+            "description": "Custom key for cache used by APIM",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK"
+          "200": {
+            "description": "OK"
           },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/cachedauthorizations/{domain}/refresh" : {
-      "post" : {
-        "tags" : [ "Cached Authorizations" ],
-        "summary" : "Refresh cached authorizations by domain and owner",
-        "operationId" : "refreshCachedAuthorizations",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The domain on which the authorizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "ownerId",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/cachedauthorizations/{domain}/refresh": {
+      "post": {
+        "tags": [
+          "Cached Authorizations"
+        ],
+        "summary": "Refresh cached authorizations by domain and owner",
+        "operationId": "refreshCachedAuthorizations",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The domain on which the authorizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "ownerId",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : { }
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/authorizations" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorization list",
-        "operationId" : "getAuthorizations_1",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "query",
-          "description" : "The domain on which the authorizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/authorizations": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorization list",
+        "operationId": "getAuthorizations_1",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "description": "The domain on which the authorizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ownerId",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The number of elements to be included in the page.",
+            "required": true,
+            "schema": {
+              "maximum": 999,
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "The index of the page, starting from 0.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
           }
-        }, {
-          "name" : "ownerId",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "The number of elements to be included in the page.",
-          "required" : true,
-          "schema" : {
-            "maximum" : 999,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 10
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "The index of the page, starting from 0.",
-          "required" : true,
-          "schema" : {
-            "minimum" : 0,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Create new authorization",
-        "operationId" : "createAuthorization",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/Authorization"
+      "post": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Create new authorization",
+        "operationId": "createAuthorization",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Authorization"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/organizations/{organizationfiscalcode}/domains/{domain}" : {
-      "get" : {
-        "tags" : [ "Enrolled Orgs" ],
-        "summary" : "Get list of stations associated to organizations enrolled to a specific domain",
-        "operationId" : "getStationsForEnrolledOrganizations",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "The enrolled organization on which the stations will be extracted.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The domain on which the stations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/organizations/{organizationfiscalcode}/domains/{domain}": {
+      "get": {
+        "tags": [
+          "Enrolled Orgs"
+        ],
+        "summary": "Get list of stations associated to organizations enrolled to a specific domain",
+        "operationId": "getStationsForEnrolledOrganizations",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "The enrolled organization on which the stations will be extracted.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The domain on which the stations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/organizations/domains/{domain}" : {
-      "get" : {
-        "tags" : [ "Enrolled Orgs" ],
-        "summary" : "Get list of organizations enrolled to a specific domain",
-        "operationId" : "getEnrolledOrganizations",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The domain on which the organizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/domains/{domain}": {
+      "get": {
+        "tags": [
+          "Enrolled Orgs"
+        ],
+        "summary": "Get list of organizations enrolled to a specific domain",
+        "operationId": "getEnrolledOrganizations",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The domain on which the organizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/cachedauthorizations" : {
-      "get" : {
-        "tags" : [ "Cached Authorizations" ],
-        "summary" : "Get cached authorizations",
-        "operationId" : "getAuthorizations",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "query",
-          "description" : "The domain on which the authorizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "ownerId",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "formatTTL",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : true
-          }
-        }, {
-          "name" : "customKeyFormat",
-          "in" : "query",
-          "description" : "Custom key for cache used by APIM",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/cachedauthorizations": {
+      "get": {
+        "tags": [
+          "Cached Authorizations"
+        ],
+        "summary": "Get cached authorizations",
+        "operationId": "getAuthorizations",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "description": "The domain on which the authorizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "ownerId",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          {
+            "name": "formatTTL",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "customKeyFormat",
+            "in": "query",
+            "description": "Custom key for cache used by APIM",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/CachedAuthorizationList"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CachedAuthorizationList"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/authorizations/subkey/{subscriptionKey}" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorization by subscription key",
-        "operationId" : "getAuthorizationBySubscriptionKey",
-        "parameters" : [ {
-          "name" : "subscriptionKey",
-          "in" : "path",
-          "description" : "The subscription key related to the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/authorizations/subkey/{subscriptionKey}": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorization by subscription key",
+        "operationId": "getAuthorizationBySubscriptionKey",
+        "parameters": [
+          {
+            "name": "subscriptionKey",
+            "in": "path",
+            "description": "The subscription key related to the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/authorizations/domains/{domain}/authorizedentities" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorized entities by domain",
-        "operationId" : "getAuthorizedEntitiesByDomain",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/authorizations/domains/{domain}/authorizedentities": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorized entities by domain",
+        "operationId": "getAuthorizedEntitiesByDomain",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "Authorization" : {
-        "required" : [ "authorized_entities", "domain", "other_metadata", "owner", "subscription_key" ],
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string",
-            "description" : "The identifier of the saved authorization, automatically generated during creation as UUID."
+  "components": {
+    "schemas": {
+      "Authorization": {
+        "required": [
+          "authorized_entities",
+          "domain",
+          "other_metadata",
+          "owner",
+          "subscription_key"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier of the saved authorization, automatically generated during creation as UUID."
           },
-          "domain" : {
-            "type" : "string",
-            "description" : "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
+          "domain": {
+            "type": "string",
+            "description": "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
           },
-          "subscription_key" : {
-            "type" : "string",
-            "description" : "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
+          "subscription_key": {
+            "type": "string",
+            "description": "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
           },
-          "description" : {
-            "type" : "string",
-            "description" : "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
+          "description": {
+            "type": "string",
+            "description": "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
           },
-          "owner" : {
-            "$ref" : "#/components/schemas/AuthorizationOwner"
+          "owner": {
+            "$ref": "#/components/schemas/AuthorizationOwner"
           },
-          "authorized_entities" : {
-            "type" : "array",
-            "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
-            "items" : {
-              "$ref" : "#/components/schemas/AuthorizationEntity"
+          "authorized_entities": {
+            "type": "array",
+            "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
+            "items": {
+              "$ref": "#/components/schemas/AuthorizationEntity"
             }
           },
-          "other_metadata" : {
-            "type" : "array",
-            "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
-            "items" : {
-              "$ref" : "#/components/schemas/AuthorizationMetadata"
+          "other_metadata": {
+            "type": "array",
+            "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
+            "items": {
+              "$ref": "#/components/schemas/AuthorizationMetadata"
             }
           },
-          "inserted_at" : {
-            "type" : "string",
-            "description" : "The date of authorization entry. This value is set only in authorization creation operations.",
-            "readOnly" : true
+          "inserted_at": {
+            "type": "string",
+            "description": "The date of authorization entry. This value is set only in authorization creation operations.",
+            "readOnly": true
           },
-          "last_update" : {
-            "type" : "string",
-            "description" : "The date of last authorization update. It is only visible as output in read requests.",
-            "readOnly" : true
+          "last_update": {
+            "type": "string",
+            "description": "The date of last authorization update. It is only visible as output in read requests.",
+            "readOnly": true
           },
-          "last_forced_refresh" : {
-            "type" : "string",
-            "description" : "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
-            "readOnly" : true
+          "last_forced_refresh": {
+            "type": "string",
+            "description": "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
+            "readOnly": true
           }
         },
-        "description" : "The list of authorization retrieved from search."
+        "description": "The list of authorization retrieved from search."
       },
-      "AuthorizationEntity" : {
-        "required" : [ "name", "value", "values" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "description" : "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
+      "AuthorizationEntity": {
+        "required": [
+          "name",
+          "value",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
           },
-          "value" : {
-            "type" : "string",
-            "description" : "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value": {
+            "type": "string",
+            "description": "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values" : {
-            "type" : "array",
-            "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items" : {
-              "type" : "string",
-              "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
-            }
-          }
-        },
-        "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
-      },
-      "AuthorizationGenericKeyValue" : {
-        "required" : [ "key", "value", "values" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string",
-            "description" : "The key used to reference the metadata into the related map."
-          },
-          "value" : {
-            "type" : "string",
-            "description" : "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
-          },
-          "values" : {
-            "type" : "array",
-            "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items" : {
-              "type" : "string",
-              "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values": {
+            "type": "array",
+            "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items": {
+              "type": "string",
+              "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description" : "A key-value map that defines the actual content of the metadata to be stored."
+        "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
       },
-      "AuthorizationMetadata" : {
-        "required" : [ "content", "name", "short_key" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "description" : "A description that defines the full name of the metadata."
+      "AuthorizationGenericKeyValue": {
+        "required": [
+          "key",
+          "value",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key used to reference the metadata into the related map."
           },
-          "short_key" : {
-            "pattern" : "_[a-zA-Z0-9]{1,3}",
-            "type" : "string",
-            "description" : "The key that defines an abbreviation by which it will be identified in cached maps."
+          "value": {
+            "type": "string",
+            "description": "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "content" : {
-            "type" : "array",
-            "description" : "A key-value map that defines the actual content of the metadata to be stored.",
-            "items" : {
-              "$ref" : "#/components/schemas/AuthorizationGenericKeyValue"
+          "values": {
+            "type": "array",
+            "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items": {
+              "type": "string",
+              "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process."
+        "description": "A key-value map that defines the actual content of the metadata to be stored."
       },
-      "AuthorizationOwner" : {
-        "required" : [ "id", "name", "type" ],
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string",
-            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+      "AuthorizationMetadata": {
+        "required": [
+          "content",
+          "name",
+          "short_key"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A description that defines the full name of the metadata."
           },
-          "name" : {
-            "type" : "string",
-            "description" : "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          "short_key": {
+            "pattern": "_[a-zA-Z0-9]{1,3}",
+            "type": "string",
+            "description": "The key that defines an abbreviation by which it will be identified in cached maps."
           },
-          "type" : {
-            "type" : "string",
-            "description" : "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
-            "enum" : [ "BROKER", "CI", "OTHER", "PSP" ]
+          "content": {
+            "type": "array",
+            "description": "A key-value map that defines the actual content of the metadata to be stored.",
+            "items": {
+              "$ref": "#/components/schemas/AuthorizationGenericKeyValue"
+            }
           }
         },
-        "description" : "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+        "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process."
       },
-      "AuthorizationList" : {
-        "required" : [ "authorizations", "page_info" ],
-        "type" : "object",
-        "properties" : {
-          "authorizations" : {
-            "type" : "array",
-            "description" : "The list of authorization retrieved from search.",
-            "items" : {
-              "$ref" : "#/components/schemas/Authorization"
+      "AuthorizationOwner": {
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          },
+          "type": {
+            "type": "string",
+            "description": "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
+            "enum": [
+              "BROKER",
+              "CI",
+              "OTHER",
+              "PSP"
+            ]
+          }
+        },
+        "description": "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+      },
+      "AuthorizationList": {
+        "required": [
+          "authorizations",
+          "page_info"
+        ],
+        "type": "object",
+        "properties": {
+          "authorizations": {
+            "type": "array",
+            "description": "The list of authorization retrieved from search.",
+            "items": {
+              "$ref": "#/components/schemas/Authorization"
             }
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
           }
         }
       },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "The page number",
-            "format" : "int32"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "The page number",
+            "format": "int32"
           },
-          "limit" : {
-            "type" : "integer",
-            "description" : "The required maximum number of items per page",
-            "format" : "int32"
+          "limit": {
+            "type": "integer",
+            "description": "The required maximum number of items per page",
+            "format": "int32"
           },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "The number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
+          "items_found": {
+            "type": "integer",
+            "description": "The number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
           },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "The total number of pages",
-            "format" : "int32"
+          "total_pages": {
+            "type": "integer",
+            "description": "The total number of pages",
+            "format": "int32"
           }
         },
-        "description" : "The information related to the paginated results."
+        "description": "The information related to the paginated results."
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "EnrolledCreditorInstitution" : {
-        "required" : [ "organization_fiscal_code", "segregation_codes" ],
-        "type" : "object",
-        "properties" : {
-          "organization_fiscal_code" : {
-            "type" : "string",
-            "description" : "The fiscal code related to the creditor institution."
+      "EnrolledCreditorInstitution": {
+        "required": [
+          "organization_fiscal_code",
+          "segregation_codes"
+        ],
+        "type": "object",
+        "properties": {
+          "organization_fiscal_code": {
+            "type": "string",
+            "description": "The fiscal code related to the creditor institution."
           },
-          "segregation_codes" : {
-            "type" : "array",
-            "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
-            "items" : {
-              "type" : "string",
-              "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain."
+          "segregation_codes": {
+            "type": "array",
+            "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
+            "items": {
+              "type": "string",
+              "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain."
             }
           }
         },
-        "description" : "The list of creditor institution enrolled to the Authorizer service."
+        "description": "The list of creditor institution enrolled to the Authorizer service."
       },
-      "EnrolledCreditorInstitutionList" : {
-        "required" : [ "creditor_institutions" ],
-        "type" : "object",
-        "properties" : {
-          "creditor_institutions" : {
-            "type" : "array",
-            "description" : "The list of creditor institution enrolled to the Authorizer service.",
-            "items" : {
-              "$ref" : "#/components/schemas/EnrolledCreditorInstitution"
+      "EnrolledCreditorInstitutionList": {
+        "required": [
+          "creditor_institutions"
+        ],
+        "type": "object",
+        "properties": {
+          "creditor_institutions": {
+            "type": "array",
+            "description": "The list of creditor institution enrolled to the Authorizer service.",
+            "items": {
+              "$ref": "#/components/schemas/EnrolledCreditorInstitution"
             }
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "environment": {
+            "type": "string"
           },
-          "dbConnection" : {
-            "type" : "string"
+          "dbConnection": {
+            "type": "string"
           }
         }
       },
-      "CachedAuthorization" : {
-        "required" : [ "ttl" ],
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string",
-            "description" : "The description that is associated with particular noteworthy items to be added to the list of cached information."
+      "CachedAuthorization": {
+        "required": [
+          "ttl"
+        ],
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description that is associated with particular noteworthy items to be added to the list of cached information."
           },
-          "owner" : {
-            "type" : "string",
-            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          "owner": {
+            "type": "string",
+            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "subscription_key" : {
-            "type" : "string",
-            "description" : "The value of the subscription key associated with the cached authorization."
+          "subscription_key": {
+            "type": "string",
+            "description": "The value of the subscription key associated with the cached authorization."
           },
-          "ttl" : {
-            "type" : "string",
-            "description" : "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
+          "ttl": {
+            "type": "string",
+            "description": "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
           }
         },
-        "description" : "The list of authorization cached in Authorizer system."
+        "description": "The list of authorization cached in Authorizer system."
       },
-      "CachedAuthorizationList" : {
-        "required" : [ "cached_authorizations" ],
-        "type" : "object",
-        "properties" : {
-          "cached_authorizations" : {
-            "type" : "array",
-            "description" : "The list of authorization cached in Authorizer system.",
-            "items" : {
-              "$ref" : "#/components/schemas/CachedAuthorization"
+      "CachedAuthorizationList": {
+        "required": [
+          "cached_authorizations"
+        ],
+        "type": "object",
+        "properties": {
+          "cached_authorizations": {
+            "type": "array",
+            "description": "The list of authorization cached in Authorizer system.",
+            "items": {
+              "$ref": "#/components/schemas/CachedAuthorization"
             }
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_core.json
+++ b/openapi/openapi_core.json
@@ -1,965 +1,911 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "platform-authorizer-config",
-    "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.14"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "platform-authorizer-config",
+    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.2.14"
   },
-  "servers": [
-    {
-      "url": "http://localhost",
-      "description": "Generated server url"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Cached Authorizations",
-      "description": "Everything about cached authorizations"
-    },
-    {
-      "name": "Authorizations",
-      "description": "Everything about authorizations"
-    }
-  ],
-  "paths": {
-    "/authorizations/{authorizationId}": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization by identifier",
-        "operationId": "getAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Cached Authorizations",
+    "description" : "Everything about cached authorizations"
+  }, {
+    "name" : "Authorizations",
+    "description" : "Everything about authorizations"
+  } ],
+  "paths" : {
+    "/authorizations/{authorizationId}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by identifier",
+        "operationId" : "getAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "put": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Update existing authorization",
-        "operationId": "updateAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+      "put" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Update existing authorization",
+        "operationId" : "updateAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "delete": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Delete existing authorization",
-        "operationId": "deleteAuthorization",
-        "parameters": [
-          {
-            "name": "authorizationId",
-            "in": "path",
-            "description": "The identifier of the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "customKeyFormat",
-            "in": "query",
-            "description": "Custom key for cache used by APIM",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": ""
-            }
+      "delete" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Delete existing authorization",
+        "operationId" : "deleteAuthorization",
+        "parameters" : [ {
+          "name" : "authorizationId",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "customKeyFormat",
+          "in" : "query",
+          "description" : "Custom key for cache used by APIM",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
+          "200" : {
+            "description" : "OK"
           },
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations/{domain}/refresh": {
-      "post": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Refresh cached authorizations by domain and owner",
-        "operationId": "refreshCachedAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
+    "/cachedauthorizations/{domain}/refresh" : {
+      "post" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Refresh cached authorizations by domain and owner",
+        "operationId" : "refreshCachedAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {}
-            }
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
+          },
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : { }
+            }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/authorizations": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization list",
-        "operationId": "getAuthorizations_1",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "description": "The number of elements to be included in the page.",
-            "required": true,
-            "schema": {
-              "maximum": 999,
-              "type": "integer",
-              "format": "int32",
-              "default": 10
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "The index of the page, starting from 0.",
-            "required": true,
-            "schema": {
-              "minimum": 0,
-              "type": "integer",
-              "format": "int32",
-              "default": 0
-            }
+    "/authorizations" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization list",
+        "operationId" : "getAuthorizations_1",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The number of elements to be included in the page.",
+          "required" : true,
+          "schema" : {
+            "maximum" : 999,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "page",
+          "in" : "query",
+          "description" : "The index of the page, starting from 0.",
+          "required" : true,
+          "schema" : {
+            "minimum" : 0,
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 0
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "403": {
-            "description": "Forbidden"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       },
-      "post": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Create new authorization",
-        "operationId": "createAuthorization",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Authorization"
+      "post" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Create new authorization",
+        "operationId" : "createAuthorization",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/Authorization"
               }
             }
           },
-          "required": true
+          "required" : true
         },
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "409" : {
+            "description" : "Conflict",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/cachedauthorizations": {
-      "get": {
-        "tags": [
-          "Cached Authorizations"
-        ],
-        "summary": "Get cached authorizations",
-        "operationId": "getAuthorizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "query",
-            "description": "The domain on which the authorizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "ownerId",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "formatTTL",
-            "in": "query",
-            "description": "The identifier of the authorizations' owner.",
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "default": true
-            }
-          },
-          {
-            "name": "customKeyFormat",
-            "in": "query",
-            "description": "Custom key for cache used by APIM",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "default": ""
-            }
+    "/cachedauthorizations" : {
+      "get" : {
+        "tags" : [ "Cached Authorizations" ],
+        "summary" : "Get cached authorizations",
+        "operationId" : "getAuthorizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "query",
+          "description" : "The domain on which the authorizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "ownerId",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "formatTTL",
+          "in" : "query",
+          "description" : "The identifier of the authorizations' owner.",
+          "required" : false,
+          "schema" : {
+            "type" : "boolean",
+            "default" : true
+          }
+        }, {
+          "name" : "customKeyFormat",
+          "in" : "query",
+          "description" : "Custom key for cache used by APIM",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CachedAuthorizationList"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CachedAuthorizationList"
                 }
               }
             }
+          },
+          "403" : {
+            "description" : "Forbidden"
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/authorizations/subkey/{subscriptionKey}": {
-      "get": {
-        "tags": [
-          "Authorizations"
-        ],
-        "summary": "Get authorization by subscription key",
-        "operationId": "getAuthorizationBySubscriptionKey",
-        "parameters": [
-          {
-            "name": "subscriptionKey",
-            "in": "path",
-            "description": "The subscription key related to the stored authorization.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/authorizations/subkey/{subscriptionKey}" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorization by subscription key",
+        "operationId" : "getAuthorizationBySubscriptionKey",
+        "parameters" : [ {
+          "name" : "subscriptionKey",
+          "in" : "path",
+          "description" : "The subscription key related to the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
-          },
-          "404": {
-            "description": "Not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthorizationList"
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "404" : {
+            "description" : "Not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
+      }
+    },
+    "/authorizations/domains/{domain}/authorizedentities" : {
+      "get" : {
+        "tags" : [ "Authorizations" ],
+        "summary" : "Get authorized entities by domain",
+        "operationId" : "getAuthorizedEntitiesByDomain",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The identifier of the stored authorization.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ]
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AuthorizationList"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized"
+          },
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden"
+          }
+        },
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "Authorization": {
-        "required": [
-          "authorized_entities",
-          "domain",
-          "other_metadata",
-          "owner",
-          "subscription_key"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the saved authorization, automatically generated during creation as UUID."
+  "components" : {
+    "schemas" : {
+      "Authorization" : {
+        "required" : [ "authorized_entities", "domain", "other_metadata", "owner", "subscription_key" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the saved authorization, automatically generated during creation as UUID."
           },
-          "domain": {
-            "type": "string",
-            "description": "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
+          "domain" : {
+            "type" : "string",
+            "description" : "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
           },
-          "description": {
-            "type": "string",
-            "description": "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
+          "description" : {
+            "type" : "string",
+            "description" : "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
           },
-          "owner": {
-            "$ref": "#/components/schemas/AuthorizationOwner"
+          "owner" : {
+            "$ref" : "#/components/schemas/AuthorizationOwner"
           },
-          "authorized_entities": {
-            "type": "array",
-            "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationEntity"
+          "authorized_entities" : {
+            "type" : "array",
+            "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationEntity"
             }
           },
-          "other_metadata": {
-            "type": "array",
-            "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationMetadata"
+          "other_metadata" : {
+            "type" : "array",
+            "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationMetadata"
             }
           },
-          "inserted_at": {
-            "type": "string",
-            "description": "The date of authorization entry. This value is set only in authorization creation operations.",
-            "readOnly": true
+          "inserted_at" : {
+            "type" : "string",
+            "description" : "The date of authorization entry. This value is set only in authorization creation operations.",
+            "readOnly" : true
           },
-          "last_update": {
-            "type": "string",
-            "description": "The date of last authorization update. It is only visible as output in read requests.",
-            "readOnly": true
+          "last_update" : {
+            "type" : "string",
+            "description" : "The date of last authorization update. It is only visible as output in read requests.",
+            "readOnly" : true
           },
-          "last_forced_refresh": {
-            "type": "string",
-            "description": "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
-            "readOnly": true
+          "last_forced_refresh" : {
+            "type" : "string",
+            "description" : "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
+            "readOnly" : true
           }
         },
-        "description": "The list of authorization retrieved from search."
+        "description" : "The list of authorization retrieved from search."
       },
-      "AuthorizationEntity": {
-        "required": [
-          "name",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
+      "AuthorizationEntity" : {
+        "required" : [ "name", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
+        "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
       },
-      "AuthorizationGenericKeyValue": {
-        "required": [
-          "key",
-          "value",
-          "values"
-        ],
-        "type": "object",
-        "properties": {
-          "key": {
-            "type": "string",
-            "description": "The key used to reference the metadata into the related map."
+      "AuthorizationGenericKeyValue" : {
+        "required" : [ "key", "value", "values" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string",
+            "description" : "The key used to reference the metadata into the related map."
           },
-          "value": {
-            "type": "string",
-            "description": "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value" : {
+            "type" : "string",
+            "description" : "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values": {
-            "type": "array",
-            "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items": {
-              "type": "string",
-              "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values" : {
+            "type" : "array",
+            "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items" : {
+              "type" : "string",
+              "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description": "A key-value map that defines the actual content of the metadata to be stored."
+        "description" : "A key-value map that defines the actual content of the metadata to be stored."
       },
-      "AuthorizationMetadata": {
-        "required": [
-          "content",
-          "name",
-          "short_key"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "A description that defines the full name of the metadata."
+      "AuthorizationMetadata" : {
+        "required" : [ "content", "name", "short_key" ],
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string",
+            "description" : "A description that defines the full name of the metadata."
           },
-          "short_key": {
-            "pattern": "_[a-zA-Z0-9]{1,3}",
-            "type": "string",
-            "description": "The key that defines an abbreviation by which it will be identified in cached maps."
+          "short_key" : {
+            "pattern" : "_[a-zA-Z0-9]{1,3}",
+            "type" : "string",
+            "description" : "The key that defines an abbreviation by which it will be identified in cached maps."
           },
-          "content": {
-            "type": "array",
-            "description": "A key-value map that defines the actual content of the metadata to be stored.",
-            "items": {
-              "$ref": "#/components/schemas/AuthorizationGenericKeyValue"
+          "content" : {
+            "type" : "array",
+            "description" : "A key-value map that defines the actual content of the metadata to be stored.",
+            "items" : {
+              "$ref" : "#/components/schemas/AuthorizationGenericKeyValue"
             }
           }
         },
-        "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process."
+        "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process."
       },
-      "AuthorizationOwner": {
-        "required": [
-          "id",
-          "name",
-          "type"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+      "AuthorizationOwner" : {
+        "required" : [ "id", "name", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "name": {
-            "type": "string",
-            "description": "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          "name" : {
+            "type" : "string",
+            "description" : "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
           },
-          "type": {
-            "type": "string",
-            "description": "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
-            "enum": [
-              "BROKER",
-              "CI",
-              "OTHER",
-              "PSP"
-            ]
+          "type" : {
+            "type" : "string",
+            "description" : "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
+            "enum" : [ "BROKER", "CI", "OTHER", "PSP" ]
           }
         },
-        "description": "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+        "description" : "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "AuthorizationList" : {
+        "required" : [ "authorizations", "page_info" ],
+        "type" : "object",
+        "properties" : {
+          "authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization retrieved from search.",
+            "items" : {
+              "$ref" : "#/components/schemas/Authorization"
+            }
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
-          },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
+          "page_info" : {
+            "$ref" : "#/components/schemas/PageInfo"
           }
         }
       },
-      "AuthorizationList": {
-        "required": [
-          "authorizations",
-          "page_info"
-        ],
-        "type": "object",
-        "properties": {
-          "authorizations": {
-            "type": "array",
-            "description": "The list of authorization retrieved from search.",
-            "items": {
-              "$ref": "#/components/schemas/Authorization"
-            }
+      "PageInfo" : {
+        "required" : [ "items_found", "limit", "page", "total_pages" ],
+        "type" : "object",
+        "properties" : {
+          "page" : {
+            "type" : "integer",
+            "description" : "The page number",
+            "format" : "int32"
           },
-          "page_info": {
-            "$ref": "#/components/schemas/PageInfo"
+          "limit" : {
+            "type" : "integer",
+            "description" : "The required maximum number of items per page",
+            "format" : "int32"
+          },
+          "items_found" : {
+            "type" : "integer",
+            "description" : "The number of items found. (The last page may have fewer elements than required)",
+            "format" : "int32"
+          },
+          "total_pages" : {
+            "type" : "integer",
+            "description" : "The total number of pages",
+            "format" : "int32"
+          }
+        },
+        "description" : "The information related to the paginated results."
+      },
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+          },
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
           }
         }
       },
-      "PageInfo": {
-        "required": [
-          "items_found",
-          "limit",
-          "page",
-          "total_pages"
-        ],
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer",
-            "description": "The page number",
-            "format": "int32"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "limit": {
-            "type": "integer",
-            "description": "The required maximum number of items per page",
-            "format": "int32"
+          "version" : {
+            "type" : "string"
           },
-          "items_found": {
-            "type": "integer",
-            "description": "The number of items found. (The last page may have fewer elements than required)",
-            "format": "int32"
+          "environment" : {
+            "type" : "string"
           },
-          "total_pages": {
-            "type": "integer",
-            "description": "The total number of pages",
-            "format": "int32"
-          }
-        },
-        "description": "The information related to the paginated results."
-      },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "version": {
-            "type": "string"
-          },
-          "environment": {
-            "type": "string"
-          },
-          "dbConnection": {
-            "type": "string"
+          "dbConnection" : {
+            "type" : "string"
           }
         }
       },
-      "CachedAuthorization": {
-        "required": [
-          "ttl"
-        ],
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string",
-            "description": "The description that is associated with particular noteworthy items to be added to the list of cached information."
+      "CachedAuthorization" : {
+        "required" : [ "ttl" ],
+        "type" : "object",
+        "properties" : {
+          "description" : {
+            "type" : "string",
+            "description" : "The description that is associated with particular noteworthy items to be added to the list of cached information."
           },
-          "owner": {
-            "type": "string",
-            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          "owner" : {
+            "type" : "string",
+            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "subscription_key": {
-            "type": "string",
-            "description": "The value of the subscription key associated with the cached authorization."
+          "subscription_key" : {
+            "type" : "string",
+            "description" : "The value of the subscription key associated with the cached authorization."
           },
-          "ttl": {
-            "type": "string",
-            "description": "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
+          "ttl" : {
+            "type" : "string",
+            "description" : "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
           }
         },
-        "description": "The list of authorization cached in Authorizer system."
+        "description" : "The list of authorization cached in Authorizer system."
       },
-      "CachedAuthorizationList": {
-        "required": [
-          "cached_authorizations"
-        ],
-        "type": "object",
-        "properties": {
-          "cached_authorizations": {
-            "type": "array",
-            "description": "The list of authorization cached in Authorizer system.",
-            "items": {
-              "$ref": "#/components/schemas/CachedAuthorization"
+      "CachedAuthorizationList" : {
+        "required" : [ "cached_authorizations" ],
+        "type" : "object",
+        "properties" : {
+          "cached_authorizations" : {
+            "type" : "array",
+            "description" : "The list of authorization cached in Authorizer system.",
+            "items" : {
+              "$ref" : "#/components/schemas/CachedAuthorization"
             }
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/openapi/openapi_core.json
+++ b/openapi/openapi_core.json
@@ -1,911 +1,1019 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "platform-authorizer-config",
-    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.2.14"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "platform-authorizer-config",
+    "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.2.14-1-PAGOPA-3258"
   },
-  "servers" : [ {
-    "url" : "http://localhost",
-    "description" : "Generated server url"
-  } ],
-  "tags" : [ {
-    "name" : "Cached Authorizations",
-    "description" : "Everything about cached authorizations"
-  }, {
-    "name" : "Authorizations",
-    "description" : "Everything about authorizations"
-  } ],
-  "paths" : {
-    "/authorizations/{authorizationId}" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorization by identifier",
-        "operationId" : "getAuthorization",
-        "parameters" : [ {
-          "name" : "authorizationId",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Cached Authorizations",
+      "description": "Everything about cached authorizations"
+    },
+    {
+      "name": "Authorizations",
+      "description": "Everything about authorizations"
+    }
+  ],
+  "paths": {
+    "/authorizations/{authorizationId}": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorization by identifier",
+        "operationId": "getAuthorization",
+        "parameters": [
+          {
+            "name": "authorizationId",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "put" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Update existing authorization",
-        "operationId" : "updateAuthorization",
-        "parameters" : [ {
-          "name" : "authorizationId",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/Authorization"
-              }
-            }
-          },
-          "required" : true
-        },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
-                }
-              }
-            }
-          },
-          "401" : {
-            "description" : "Unauthorized"
-          },
-          "429" : {
-            "description" : "Too many requests"
-          },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
-            }
-          },
-          "403" : {
-            "description" : "Forbidden"
-          },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
-                }
-              }
+      "put": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Update existing authorization",
+        "operationId": "updateAuthorization",
+        "parameters": [
+          {
+            "name": "authorizationId",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
             }
           }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Authorization"
+              }
+            }
+          },
+          "required": true
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "delete" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Delete existing authorization",
-        "operationId" : "deleteAuthorization",
-        "parameters" : [ {
-          "name" : "authorizationId",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "customKeyFormat",
-          "in" : "query",
-          "description" : "Custom key for cache used by APIM",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+      "delete": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Delete existing authorization",
+        "operationId": "deleteAuthorization",
+        "parameters": [
+          {
+            "name": "authorizationId",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "customKeyFormat",
+            "in": "query",
+            "description": "Custom key for cache used by APIM",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK"
+          "200": {
+            "description": "OK"
           },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/cachedauthorizations/{domain}/refresh" : {
-      "post" : {
-        "tags" : [ "Cached Authorizations" ],
-        "summary" : "Refresh cached authorizations by domain and owner",
-        "operationId" : "refreshCachedAuthorizations",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The domain on which the authorizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "ownerId",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/cachedauthorizations/{domain}/refresh": {
+      "post": {
+        "tags": [
+          "Cached Authorizations"
+        ],
+        "summary": "Refresh cached authorizations by domain and owner",
+        "operationId": "refreshCachedAuthorizations",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The domain on which the authorizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "ownerId",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : { }
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {}
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/authorizations" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorization list",
-        "operationId" : "getAuthorizations_1",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "query",
-          "description" : "The domain on which the authorizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/authorizations": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorization list",
+        "operationId": "getAuthorizations_1",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "description": "The domain on which the authorizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ownerId",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The number of elements to be included in the page.",
+            "required": true,
+            "schema": {
+              "maximum": 999,
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "The index of the page, starting from 0.",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
           }
-        }, {
-          "name" : "ownerId",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "limit",
-          "in" : "query",
-          "description" : "The number of elements to be included in the page.",
-          "required" : true,
-          "schema" : {
-            "maximum" : 999,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 10
-          }
-        }, {
-          "name" : "page",
-          "in" : "query",
-          "description" : "The index of the page, starting from 0.",
-          "required" : true,
-          "schema" : {
-            "minimum" : 0,
-            "type" : "integer",
-            "format" : "int32",
-            "default" : 0
-          }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       },
-      "post" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Create new authorization",
-        "operationId" : "createAuthorization",
-        "requestBody" : {
-          "content" : {
-            "application/json" : {
-              "schema" : {
-                "$ref" : "#/components/schemas/Authorization"
+      "post": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Create new authorization",
+        "operationId": "createAuthorization",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Authorization"
               }
             }
           },
-          "required" : true
+          "required": true
         },
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "409" : {
-            "description" : "Conflict",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/cachedauthorizations" : {
-      "get" : {
-        "tags" : [ "Cached Authorizations" ],
-        "summary" : "Get cached authorizations",
-        "operationId" : "getAuthorizations",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "query",
-          "description" : "The domain on which the authorizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "ownerId",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "formatTTL",
-          "in" : "query",
-          "description" : "The identifier of the authorizations' owner.",
-          "required" : false,
-          "schema" : {
-            "type" : "boolean",
-            "default" : true
-          }
-        }, {
-          "name" : "customKeyFormat",
-          "in" : "query",
-          "description" : "Custom key for cache used by APIM",
-          "required" : false,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/cachedauthorizations": {
+      "get": {
+        "tags": [
+          "Cached Authorizations"
+        ],
+        "summary": "Get cached authorizations",
+        "operationId": "getAuthorizations",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "query",
+            "description": "The domain on which the authorizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "ownerId",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          {
+            "name": "formatTTL",
+            "in": "query",
+            "description": "The identifier of the authorizations' owner.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "customKeyFormat",
+            "in": "query",
+            "description": "Custom key for cache used by APIM",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/CachedAuthorizationList"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CachedAuthorizationList"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/authorizations/subkey/{subscriptionKey}" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorization by subscription key",
-        "operationId" : "getAuthorizationBySubscriptionKey",
-        "parameters" : [ {
-          "name" : "subscriptionKey",
-          "in" : "path",
-          "description" : "The subscription key related to the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/authorizations/subkey/{subscriptionKey}": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorization by subscription key",
+        "operationId": "getAuthorizationBySubscriptionKey",
+        "parameters": [
+          {
+            "name": "subscriptionKey",
+            "in": "path",
+            "description": "The subscription key related to the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "404" : {
-            "description" : "Not found",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/authorizations/domains/{domain}/authorizedentities" : {
-      "get" : {
-        "tags" : [ "Authorizations" ],
-        "summary" : "Get authorized entities by domain",
-        "operationId" : "getAuthorizedEntitiesByDomain",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The identifier of the stored authorization.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/authorizations/domains/{domain}/authorizedentities": {
+      "get": {
+        "tags": [
+          "Authorizations"
+        ],
+        "summary": "Get authorized entities by domain",
+        "operationId": "getAuthorizedEntitiesByDomain",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The identifier of the stored authorization.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AuthorizationList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthorizationList"
                 }
               }
             }
           },
-          "401" : {
-            "description" : "Unauthorized"
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "Authorization" : {
-        "required" : [ "authorized_entities", "domain", "other_metadata", "owner", "subscription_key" ],
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string",
-            "description" : "The identifier of the saved authorization, automatically generated during creation as UUID."
+  "components": {
+    "schemas": {
+      "Authorization": {
+        "required": [
+          "authorized_entities",
+          "domain",
+          "other_metadata",
+          "owner",
+          "subscription_key"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier of the saved authorization, automatically generated during creation as UUID."
           },
-          "domain" : {
-            "type" : "string",
-            "description" : "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
+          "domain": {
+            "type": "string",
+            "description": "The domain to which the authorization belongs, within which it has validity. Typically, it is defined by choosing from a pool of tags that already exist and are used by the various membership domains."
           },
-          "subscription_key" : {
-            "type" : "string",
-            "description" : "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
+          "subscription_key": {
+            "type": "string",
+            "description": "The value of the subscription key to be associated with the stored authorization. This key is assigned to an entity that wants to interface with a pagoPA service via APIM, and is the pivotal element on which the Authorizer system will make its evaluations. No two authorizations can exist with the same domain-subscription_key value pair."
           },
-          "description" : {
-            "type" : "string",
-            "description" : "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
+          "description": {
+            "type": "string",
+            "description": "An optional description useful to add more information about the scope of the authorization, defining information also impossible to include in the other tags."
           },
-          "owner" : {
-            "$ref" : "#/components/schemas/AuthorizationOwner"
+          "owner": {
+            "$ref": "#/components/schemas/AuthorizationOwner"
           },
-          "authorized_entities" : {
-            "type" : "array",
-            "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
-            "items" : {
-              "$ref" : "#/components/schemas/AuthorizationEntity"
+          "authorized_entities": {
+            "type": "array",
+            "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier.",
+            "items": {
+              "$ref": "#/components/schemas/AuthorizationEntity"
             }
           },
-          "other_metadata" : {
-            "type" : "array",
-            "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
-            "items" : {
-              "$ref" : "#/components/schemas/AuthorizationMetadata"
+          "other_metadata": {
+            "type": "array",
+            "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process.",
+            "items": {
+              "$ref": "#/components/schemas/AuthorizationMetadata"
             }
           },
-          "inserted_at" : {
-            "type" : "string",
-            "description" : "The date of authorization entry. This value is set only in authorization creation operations.",
-            "readOnly" : true
+          "inserted_at": {
+            "type": "string",
+            "description": "The date of authorization entry. This value is set only in authorization creation operations.",
+            "readOnly": true
           },
-          "last_update" : {
-            "type" : "string",
-            "description" : "The date of last authorization update. It is only visible as output in read requests.",
-            "readOnly" : true
+          "last_update": {
+            "type": "string",
+            "description": "The date of last authorization update. It is only visible as output in read requests.",
+            "readOnly": true
           },
-          "last_forced_refresh" : {
-            "type" : "string",
-            "description" : "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
-            "readOnly" : true
+          "last_forced_refresh": {
+            "type": "string",
+            "description": "The date of last forced refresh of the authorization. It is updated only when the forced refresh API is executed.",
+            "readOnly": true
           }
         },
-        "description" : "The list of authorization retrieved from search."
+        "description": "The list of authorization retrieved from search."
       },
-      "AuthorizationEntity" : {
-        "required" : [ "name", "value", "values" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "description" : "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
+      "AuthorizationEntity": {
+        "required": [
+          "name",
+          "value",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name or the description associated to the authorization entity in order to reference it in a more human-readable mode."
           },
-          "value" : {
-            "type" : "string",
-            "description" : "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "value": {
+            "type": "string",
+            "description": "The single simple value related to an entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "values" : {
-            "type" : "array",
-            "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items" : {
-              "type" : "string",
-              "description" : "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
-            }
-          }
-        },
-        "description" : "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
-      },
-      "AuthorizationGenericKeyValue" : {
-        "required" : [ "key", "value", "values" ],
-        "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string",
-            "description" : "The key used to reference the metadata into the related map."
-          },
-          "value" : {
-            "type" : "string",
-            "description" : "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
-          },
-          "values" : {
-            "type" : "array",
-            "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
-            "items" : {
-              "type" : "string",
-              "description" : "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
+          "values": {
+            "type": "array",
+            "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items": {
+              "type": "string",
+              "description": "The multiple composite sub-values which concatenation forms a complex entity to be authorized to access within an authorization. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description" : "A key-value map that defines the actual content of the metadata to be stored."
+        "description": "The authorized entity list, which are the resource identifiers that the caller includes in requests that define which objects the entity is authorized to operate on. It consists of a key-value map in which the entity name and its identifier are defined, respectively, in order to make maintenance easier."
       },
-      "AuthorizationMetadata" : {
-        "required" : [ "content", "name", "short_key" ],
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string",
-            "description" : "A description that defines the full name of the metadata."
+      "AuthorizationGenericKeyValue": {
+        "required": [
+          "key",
+          "value",
+          "values"
+        ],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "description": "The key used to reference the metadata into the related map."
           },
-          "short_key" : {
-            "pattern" : "_[a-zA-Z0-9]{1,3}",
-            "type" : "string",
-            "description" : "The key that defines an abbreviation by which it will be identified in cached maps."
+          "value": {
+            "type": "string",
+            "description": "The single simple value related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
           },
-          "content" : {
-            "type" : "array",
-            "description" : "A key-value map that defines the actual content of the metadata to be stored.",
-            "items" : {
-              "$ref" : "#/components/schemas/AuthorizationGenericKeyValue"
+          "values": {
+            "type": "array",
+            "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object.",
+            "items": {
+              "type": "string",
+              "description": "The set of values related to the metadata. Only one between 'value' and 'values' tag at a time can exists in this object."
             }
           }
         },
-        "description" : "The list of authorization metadata, useful for performing other types of computation after the authorization process."
+        "description": "A key-value map that defines the actual content of the metadata to be stored."
       },
-      "AuthorizationOwner" : {
-        "required" : [ "id", "name", "type" ],
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string",
-            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+      "AuthorizationMetadata": {
+        "required": [
+          "content",
+          "name",
+          "short_key"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "A description that defines the full name of the metadata."
           },
-          "name" : {
-            "type" : "string",
-            "description" : "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          "short_key": {
+            "pattern": "_[a-zA-Z0-9]{1,3}",
+            "type": "string",
+            "description": "The key that defines an abbreviation by which it will be identified in cached maps."
           },
-          "type" : {
-            "type" : "string",
-            "description" : "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
-            "enum" : [ "BROKER", "CI", "OTHER", "PSP" ]
+          "content": {
+            "type": "array",
+            "description": "A key-value map that defines the actual content of the metadata to be stored.",
+            "items": {
+              "$ref": "#/components/schemas/AuthorizationGenericKeyValue"
+            }
           }
         },
-        "description" : "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+        "description": "The list of authorization metadata, useful for performing other types of computation after the authorization process."
       },
-      "AuthorizationList" : {
-        "required" : [ "authorizations", "page_info" ],
-        "type" : "object",
-        "properties" : {
-          "authorizations" : {
-            "type" : "array",
-            "description" : "The list of authorization retrieved from search.",
-            "items" : {
-              "$ref" : "#/components/schemas/Authorization"
+      "AuthorizationOwner": {
+        "required": [
+          "id",
+          "name",
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the authorization owner, useful in order to make an authorization more human-readable. It can be the entity's business name or any other information that helps its recognition."
+          },
+          "type": {
+            "type": "string",
+            "description": "The authorization owner type, useful both for adding an additional recognizable 'label' to the subject and for use as a search filter.",
+            "enum": [
+              "BROKER",
+              "CI",
+              "OTHER",
+              "PSP"
+            ]
+          }
+        },
+        "description": "The information about the owner of the authorization. These information are required in order to make maintenance easier and performs some kind of search operations."
+      },
+      "AuthorizationList": {
+        "required": [
+          "authorizations",
+          "page_info"
+        ],
+        "type": "object",
+        "properties": {
+          "authorizations": {
+            "type": "array",
+            "description": "The list of authorization retrieved from search.",
+            "items": {
+              "$ref": "#/components/schemas/Authorization"
             }
           },
-          "page_info" : {
-            "$ref" : "#/components/schemas/PageInfo"
+          "page_info": {
+            "$ref": "#/components/schemas/PageInfo"
           }
         }
       },
-      "PageInfo" : {
-        "required" : [ "items_found", "limit", "page", "total_pages" ],
-        "type" : "object",
-        "properties" : {
-          "page" : {
-            "type" : "integer",
-            "description" : "The page number",
-            "format" : "int32"
+      "PageInfo": {
+        "required": [
+          "items_found",
+          "limit",
+          "page",
+          "total_pages"
+        ],
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "description": "The page number",
+            "format": "int32"
           },
-          "limit" : {
-            "type" : "integer",
-            "description" : "The required maximum number of items per page",
-            "format" : "int32"
+          "limit": {
+            "type": "integer",
+            "description": "The required maximum number of items per page",
+            "format": "int32"
           },
-          "items_found" : {
-            "type" : "integer",
-            "description" : "The number of items found. (The last page may have fewer elements than required)",
-            "format" : "int32"
+          "items_found": {
+            "type": "integer",
+            "description": "The number of items found. (The last page may have fewer elements than required)",
+            "format": "int32"
           },
-          "total_pages" : {
-            "type" : "integer",
-            "description" : "The total number of pages",
-            "format" : "int32"
+          "total_pages": {
+            "type": "integer",
+            "description": "The total number of pages",
+            "format": "int32"
           }
         },
-        "description" : "The information related to the paginated results."
+        "description": "The information related to the paginated results."
       },
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "environment": {
+            "type": "string"
           },
-          "dbConnection" : {
-            "type" : "string"
+          "dbConnection": {
+            "type": "string"
           }
         }
       },
-      "CachedAuthorization" : {
-        "required" : [ "ttl" ],
-        "type" : "object",
-        "properties" : {
-          "description" : {
-            "type" : "string",
-            "description" : "The description that is associated with particular noteworthy items to be added to the list of cached information."
+      "CachedAuthorization": {
+        "required": [
+          "ttl"
+        ],
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "description": "The description that is associated with particular noteworthy items to be added to the list of cached information."
           },
-          "owner" : {
-            "type" : "string",
-            "description" : "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
+          "owner": {
+            "type": "string",
+            "description": "The identifier of the authorization owner. This can be the fiscal code of the entity/intermediary or other information that uniquely identifies that entity."
           },
-          "subscription_key" : {
-            "type" : "string",
-            "description" : "The value of the subscription key associated with the cached authorization."
+          "subscription_key": {
+            "type": "string",
+            "description": "The value of the subscription key associated with the cached authorization."
           },
-          "ttl" : {
-            "type" : "string",
-            "description" : "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
+          "ttl": {
+            "type": "string",
+            "description": "The remaining Time-to-Live related to the cached authorization. This can be formatted either in seconds format or in a particular format that follows the structure 'XXh YYm ZZs'."
           }
         },
-        "description" : "The list of authorization cached in Authorizer system."
+        "description": "The list of authorization cached in Authorizer system."
       },
-      "CachedAuthorizationList" : {
-        "required" : [ "cached_authorizations" ],
-        "type" : "object",
-        "properties" : {
-          "cached_authorizations" : {
-            "type" : "array",
-            "description" : "The list of authorization cached in Authorizer system.",
-            "items" : {
-              "$ref" : "#/components/schemas/CachedAuthorization"
+      "CachedAuthorizationList": {
+        "required": [
+          "cached_authorizations"
+        ],
+        "type": "object",
+        "properties": {
+          "cached_authorizations": {
+            "type": "array",
+            "description": "The list of authorization cached in Authorizer system.",
+            "items": {
+              "$ref": "#/components/schemas/CachedAuthorization"
             }
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_enrolledci.json
+++ b/openapi/openapi_enrolledci.json
@@ -1,260 +1,286 @@
 {
-  "openapi" : "3.0.1",
-  "info" : {
-    "title" : "platform-authorizer-config",
-    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
-    "termsOfService" : "https://www.pagopa.gov.it/",
-    "version" : "0.2.14"
+  "openapi": "3.0.1",
+  "info": {
+    "title": "platform-authorizer-config",
+    "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService": "https://www.pagopa.gov.it/",
+    "version": "0.2.14-1-PAGOPA-3258"
   },
-  "servers" : [ {
-    "url" : "http://localhost",
-    "description" : "Generated server url"
-  } ],
-  "tags" : [ {
-    "name" : "Enrolled Orgs",
-    "description" : "Everything about enrolled organizations"
-  } ],
-  "paths" : {
-    "/organizations/{organizationfiscalcode}/domains/{domain}" : {
-      "get" : {
-        "tags" : [ "Enrolled Orgs" ],
-        "summary" : "Get list of stations associated to organizations enrolled to a specific domain",
-        "operationId" : "getStationsForEnrolledOrganizations",
-        "parameters" : [ {
-          "name" : "organizationfiscalcode",
-          "in" : "path",
-          "description" : "The enrolled organization on which the stations will be extracted.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        }, {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The domain on which the stations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
-          }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Enrolled Orgs",
+      "description": "Everything about enrolled organizations"
+    }
+  ],
+  "paths": {
+    "/organizations/{organizationfiscalcode}/domains/{domain}": {
+      "get": {
+        "tags": [
+          "Enrolled Orgs"
+        ],
+        "summary": "Get list of stations associated to organizations enrolled to a specific domain",
+        "operationId": "getStationsForEnrolledOrganizations",
+        "parameters": [
+          {
+            "name": "organizationfiscalcode",
+            "in": "path",
+            "description": "The enrolled organization on which the stations will be extracted.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           },
-          "429" : {
-            "description" : "Too many requests"
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The domain on which the stations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "429": {
+            "description": "Too many requests"
+          },
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/organizations/domains/{domain}" : {
-      "get" : {
-        "tags" : [ "Enrolled Orgs" ],
-        "summary" : "Get list of organizations enrolled to a specific domain",
-        "operationId" : "getEnrolledOrganizations",
-        "parameters" : [ {
-          "name" : "domain",
-          "in" : "path",
-          "description" : "The domain on which the organizations will be filtered.",
-          "required" : true,
-          "schema" : {
-            "type" : "string"
+    "/organizations/domains/{domain}": {
+      "get": {
+        "tags": [
+          "Enrolled Orgs"
+        ],
+        "summary": "Get list of organizations enrolled to a specific domain",
+        "operationId": "getEnrolledOrganizations",
+        "parameters": [
+          {
+            "name": "domain",
+            "in": "path",
+            "description": "The domain on which the organizations will be filtered.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
           }
-        } ],
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     },
-    "/info" : {
-      "get" : {
-        "tags" : [ "Home" ],
-        "summary" : "Return OK if application is started",
-        "operationId" : "healthCheck",
-        "responses" : {
-          "401" : {
-            "description" : "Unauthorized"
+    "/info": {
+      "get": {
+        "tags": [
+          "Home"
+        ],
+        "summary": "Return OK if application is started",
+        "operationId": "healthCheck",
+        "responses": {
+          "401": {
+            "description": "Unauthorized"
           },
-          "429" : {
-            "description" : "Too many requests"
+          "429": {
+            "description": "Too many requests"
           },
-          "500" : {
-            "description" : "Service unavailable",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "500": {
+            "description": "Service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403" : {
-            "description" : "Forbidden"
+          "403": {
+            "description": "Forbidden"
           },
-          "200" : {
-            "description" : "OK",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/AppInfo"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "400" : {
-            "description" : "Bad Request",
-            "content" : {
-              "application/json" : {
-                "schema" : {
-                  "$ref" : "#/components/schemas/ProblemJson"
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security" : [ {
-          "ApiKey" : [ ]
-        } ]
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
       }
     }
   },
-  "components" : {
-    "schemas" : {
-      "ProblemJson" : {
-        "type" : "object",
-        "properties" : {
-          "title" : {
-            "type" : "string",
-            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+  "components": {
+    "schemas": {
+      "ProblemJson": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "status" : {
-            "maximum" : 600,
-            "minimum" : 100,
-            "type" : "integer",
-            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format" : "int32",
-            "example" : 200
+          "status": {
+            "maximum": 600,
+            "minimum": 100,
+            "type": "integer",
+            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format": "int32",
+            "example": 200
           },
-          "detail" : {
-            "type" : "string",
-            "description" : "A human readable explanation specific to this occurrence of the problem.",
-            "example" : "There was an error processing the request"
+          "detail": {
+            "type": "string",
+            "description": "A human readable explanation specific to this occurrence of the problem.",
+            "example": "There was an error processing the request"
           }
         }
       },
-      "EnrolledCreditorInstitution" : {
-        "required" : [ "organization_fiscal_code", "segregation_codes" ],
-        "type" : "object",
-        "properties" : {
-          "organization_fiscal_code" : {
-            "type" : "string",
-            "description" : "The fiscal code related to the creditor institution."
+      "EnrolledCreditorInstitution": {
+        "required": [
+          "organization_fiscal_code",
+          "segregation_codes"
+        ],
+        "type": "object",
+        "properties": {
+          "organization_fiscal_code": {
+            "type": "string",
+            "description": "The fiscal code related to the creditor institution."
           },
-          "segregation_codes" : {
-            "type" : "array",
-            "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
-            "items" : {
-              "type" : "string",
-              "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain."
+          "segregation_codes": {
+            "type": "array",
+            "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
+            "items": {
+              "type": "string",
+              "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain."
             }
           }
         },
-        "description" : "The list of creditor institution enrolled to the Authorizer service."
+        "description": "The list of creditor institution enrolled to the Authorizer service."
       },
-      "EnrolledCreditorInstitutionList" : {
-        "required" : [ "creditor_institutions" ],
-        "type" : "object",
-        "properties" : {
-          "creditor_institutions" : {
-            "type" : "array",
-            "description" : "The list of creditor institution enrolled to the Authorizer service.",
-            "items" : {
-              "$ref" : "#/components/schemas/EnrolledCreditorInstitution"
+      "EnrolledCreditorInstitutionList": {
+        "required": [
+          "creditor_institutions"
+        ],
+        "type": "object",
+        "properties": {
+          "creditor_institutions": {
+            "type": "array",
+            "description": "The list of creditor institution enrolled to the Authorizer service.",
+            "items": {
+              "$ref": "#/components/schemas/EnrolledCreditorInstitution"
             }
           }
         }
       },
-      "AppInfo" : {
-        "type" : "object",
-        "properties" : {
-          "name" : {
-            "type" : "string"
+      "AppInfo": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
           },
-          "version" : {
-            "type" : "string"
+          "version": {
+            "type": "string"
           },
-          "environment" : {
-            "type" : "string"
+          "environment": {
+            "type": "string"
           },
-          "dbConnection" : {
-            "type" : "string"
+          "dbConnection": {
+            "type": "string"
           }
         }
       }
     },
-    "securitySchemes" : {
-      "ApiKey" : {
-        "type" : "apiKey",
-        "description" : "The API key to access this function app.",
-        "name" : "Ocp-Apim-Subscription-Key",
-        "in" : "header"
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "The API key to access this function app.",
+        "name": "Ocp-Apim-Subscription-Key",
+        "in": "header"
       }
     }
   }

--- a/openapi/openapi_enrolledci.json
+++ b/openapi/openapi_enrolledci.json
@@ -1,286 +1,260 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "platform-authorizer-config",
-    "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
-    "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.14"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "platform-authorizer-config",
+    "description" : "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
+    "termsOfService" : "https://www.pagopa.gov.it/",
+    "version" : "0.2.14"
   },
-  "servers": [
-    {
-      "url": "http://localhost",
-      "description": "Generated server url"
-    }
-  ],
-  "tags": [
-    {
-      "name": "Enrolled Orgs",
-      "description": "Everything about enrolled organizations"
-    }
-  ],
-  "paths": {
-    "/organizations/{organizationfiscalcode}/domains/{domain}": {
-      "get": {
-        "tags": [
-          "Enrolled Orgs"
-        ],
-        "summary": "Get list of stations associated to organizations enrolled to a specific domain",
-        "operationId": "getStationsForEnrolledOrganizations",
-        "parameters": [
-          {
-            "name": "organizationfiscalcode",
-            "in": "path",
-            "description": "The enrolled organization on which the stations will be extracted.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the stations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "tags" : [ {
+    "name" : "Enrolled Orgs",
+    "description" : "Everything about enrolled organizations"
+  } ],
+  "paths" : {
+    "/organizations/{organizationfiscalcode}/domains/{domain}" : {
+      "get" : {
+        "tags" : [ "Enrolled Orgs" ],
+        "summary" : "Get list of stations associated to organizations enrolled to a specific domain",
+        "operationId" : "getStationsForEnrolledOrganizations",
+        "parameters" : [ {
+          "name" : "organizationfiscalcode",
+          "in" : "path",
+          "description" : "The enrolled organization on which the stations will be extracted.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        }, {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the stations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/organizations/domains/{domain}": {
-      "get": {
-        "tags": [
-          "Enrolled Orgs"
-        ],
-        "summary": "Get list of organizations enrolled to a specific domain",
-        "operationId": "getEnrolledOrganizations",
-        "parameters": [
-          {
-            "name": "domain",
-            "in": "path",
-            "description": "The domain on which the organizations will be filtered.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
+    "/organizations/domains/{domain}" : {
+      "get" : {
+        "tags" : [ "Enrolled Orgs" ],
+        "summary" : "Get list of organizations enrolled to a specific domain",
+        "operationId" : "getEnrolledOrganizations",
+        "parameters" : [ {
+          "name" : "domain",
+          "in" : "path",
+          "description" : "The domain on which the organizations will be filtered.",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
           }
-        ],
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+        } ],
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "401": {
-            "description": "Unauthorized"
+          "429" : {
+            "description" : "Too many requests"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EnrolledCreditorInstitutionList"
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/EnrolledCreditorInstitutionList"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     },
-    "/info": {
-      "get": {
-        "tags": [
-          "Home"
-        ],
-        "summary": "Return OK if application is started",
-        "operationId": "healthCheck",
-        "responses": {
-          "429": {
-            "description": "Too many requests"
+    "/info" : {
+      "get" : {
+        "tags" : [ "Home" ],
+        "summary" : "Return OK if application is started",
+        "operationId" : "healthCheck",
+        "responses" : {
+          "401" : {
+            "description" : "Unauthorized"
           },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "429" : {
+            "description" : "Too many requests"
+          },
+          "500" : {
+            "description" : "Service unavailable",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           },
-          "401": {
-            "description": "Unauthorized"
+          "403" : {
+            "description" : "Forbidden"
           },
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AppInfo"
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/AppInfo"
                 }
               }
             }
           },
-          "403": {
-            "description": "Forbidden"
-          },
-          "500": {
-            "description": "Service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemJson"
+          "400" : {
+            "description" : "Bad Request",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ProblemJson"
                 }
               }
             }
           }
         },
-        "security": [
-          {
-            "ApiKey": []
-          }
-        ]
+        "security" : [ {
+          "ApiKey" : [ ]
+        } ]
       }
     }
   },
-  "components": {
-    "schemas": {
-      "EnrolledCreditorInstitution": {
-        "required": [
-          "organization_fiscal_code",
-          "segregation_codes"
-        ],
-        "type": "object",
-        "properties": {
-          "organization_fiscal_code": {
-            "type": "string",
-            "description": "The fiscal code related to the creditor institution."
+  "components" : {
+    "schemas" : {
+      "ProblemJson" : {
+        "type" : "object",
+        "properties" : {
+          "title" : {
+            "type" : "string",
+            "description" : "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
           },
-          "segregation_codes": {
-            "type": "array",
-            "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
-            "items": {
-              "type": "string",
-              "description": "The list of segregation codes used by the creditor institution to register a station for the required service domain."
+          "status" : {
+            "maximum" : 600,
+            "minimum" : 100,
+            "type" : "integer",
+            "description" : "The HTTP status code generated by the origin server for this occurrence of the problem.",
+            "format" : "int32",
+            "example" : 200
+          },
+          "detail" : {
+            "type" : "string",
+            "description" : "A human readable explanation specific to this occurrence of the problem.",
+            "example" : "There was an error processing the request"
+          }
+        }
+      },
+      "EnrolledCreditorInstitution" : {
+        "required" : [ "organization_fiscal_code", "segregation_codes" ],
+        "type" : "object",
+        "properties" : {
+          "organization_fiscal_code" : {
+            "type" : "string",
+            "description" : "The fiscal code related to the creditor institution."
+          },
+          "segregation_codes" : {
+            "type" : "array",
+            "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain.",
+            "items" : {
+              "type" : "string",
+              "description" : "The list of segregation codes used by the creditor institution to register a station for the required service domain."
             }
           }
         },
-        "description": "The list of creditor institution enrolled to the Authorizer service."
+        "description" : "The list of creditor institution enrolled to the Authorizer service."
       },
-      "EnrolledCreditorInstitutionList": {
-        "required": [
-          "creditor_institutions"
-        ],
-        "type": "object",
-        "properties": {
-          "creditor_institutions": {
-            "type": "array",
-            "description": "The list of creditor institution enrolled to the Authorizer service.",
-            "items": {
-              "$ref": "#/components/schemas/EnrolledCreditorInstitution"
+      "EnrolledCreditorInstitutionList" : {
+        "required" : [ "creditor_institutions" ],
+        "type" : "object",
+        "properties" : {
+          "creditor_institutions" : {
+            "type" : "array",
+            "description" : "The list of creditor institution enrolled to the Authorizer service.",
+            "items" : {
+              "$ref" : "#/components/schemas/EnrolledCreditorInstitution"
             }
           }
         }
       },
-      "ProblemJson": {
-        "type": "object",
-        "properties": {
-          "title": {
-            "type": "string",
-            "description": "A short, summary of the problem type. Written in english and readable for engineers (usually not suited for non technical stakeholders and not localized); example: Service Unavailable"
+      "AppInfo" : {
+        "type" : "object",
+        "properties" : {
+          "name" : {
+            "type" : "string"
           },
-          "status": {
-            "maximum": 600,
-            "minimum": 100,
-            "type": "integer",
-            "description": "The HTTP status code generated by the origin server for this occurrence of the problem.",
-            "format": "int32",
-            "example": 200
+          "version" : {
+            "type" : "string"
           },
-          "detail": {
-            "type": "string",
-            "description": "A human readable explanation specific to this occurrence of the problem.",
-            "example": "There was an error processing the request"
-          }
-        }
-      },
-      "AppInfo": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
+          "environment" : {
+            "type" : "string"
           },
-          "version": {
-            "type": "string"
-          },
-          "environment": {
-            "type": "string"
-          },
-          "dbConnection": {
-            "type": "string"
+          "dbConnection" : {
+            "type" : "string"
           }
         }
       }
     },
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "description": "The API key to access this function app.",
-        "name": "Ocp-Apim-Subscription-Key",
-        "in": "header"
+    "securitySchemes" : {
+      "ApiKey" : {
+        "type" : "apiKey",
+        "description" : "The API key to access this function app.",
+        "name" : "Ocp-Apim-Subscription-Key",
+        "in" : "header"
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>it.gov.pagopa</groupId>
   <artifactId>platform-authorizer-config</artifactId>
-  <version>0.2.14</version>
+  <version>0.2.14-1-PAGOPA-3258</version>
   <name>pagopa-platform-authorizer-config</name>
   <description>A microservice that provides a set of APIs to manage authorization records for the Authorizer system.</description>
 

--- a/src/main/java/it/gov/pagopa/authorizer/config/config/SchedulerConfiguration.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/config/SchedulerConfiguration.java
@@ -1,0 +1,10 @@
+package it.gov.pagopa.authorizer.config.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "authorizer.schedule.enabled", matchIfMissing = false)
+public class SchedulerConfiguration {}

--- a/src/main/java/it/gov/pagopa/authorizer/config/controller/AuthorizationController.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/controller/AuthorizationController.java
@@ -11,7 +11,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import it.gov.pagopa.authorizer.config.model.ProblemJson;
 import it.gov.pagopa.authorizer.config.model.authorization.Authorization;
 import it.gov.pagopa.authorizer.config.model.authorization.AuthorizationList;
+import it.gov.pagopa.authorizer.config.model.authorization.AuthorizedEntityList;
 import it.gov.pagopa.authorizer.config.service.AuthorizationService;
+import it.gov.pagopa.authorizer.config.util.Constants;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
@@ -222,4 +225,33 @@ public class AuthorizationController {
     authorizationService.deleteAuthorization(authorizationId, customKeyFormat);
     return ResponseEntity.noContent().build();
   }
+
+
+    /**
+     * GET /domains/{domain}/authorizedentities : Get authorized entities for passed domain
+     *
+     * @param domain The domain on which the authorized entities will be filtered.
+     * @return OK (status code 200) or Too many request (status code 429) or Service unavailable (status code 500)
+     */
+    @Operation(
+            summary = "Get authorized entities by domain",
+            security = {
+                    @SecurityRequirement(name = "ApiKey")
+            },
+            tags = { "Authorizations" })
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "OK", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = AuthorizationList.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema())),
+                    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema())),
+                    @ApiResponse(responseCode = "429", description = "Too many requests", content = @Content(schema = @Schema())),
+                    @ApiResponse(responseCode = "500", description = "Service unavailable", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = ProblemJson.class)))
+            })
+    @GetMapping(value = "/domains/{domain}/authorizedentities", produces = {MediaType.APPLICATION_JSON_VALUE})
+    public ResponseEntity<AuthorizedEntityList> getAuthorizedEntitiesByDomain(
+            @Parameter(description = "The identifier of the stored authorization.", required = true)
+            @PathVariable("domain") String domain) {
+        MDC.put(Constants.MDC_MAX_RESPONSE_BODY_SIZE_FOR_LOG, "3000");
+        return ResponseEntity.ok(authorizationService.getAuthorizedEntitiesByDomain(domain));
+    }
 }

--- a/src/main/java/it/gov/pagopa/authorizer/config/exception/AppError.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/exception/AppError.java
@@ -38,8 +38,6 @@ public enum AppError {
   INTERNAL_SERVER_ERROR_MULTIPLE_AUTHORIZATION_WITH_SAME_SUBKEY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "There are multiple authorization with the same subscription key [%s]. Please, check if they are correct."),
 
   INTERNAL_SERVER_ERROR_RETRIEVE_AUTHORIZED_ENTITY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while retrieving the authorized entity for domain [%s]."),
-
-  INTERNAL_SERVER_ERROR_GENERATE_AUTHORIZED_ENTITY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while generating the authorized entity for domain [%s].")
   ;
 
   public final HttpStatus httpStatus;

--- a/src/main/java/it/gov/pagopa/authorizer/config/exception/AppError.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/exception/AppError.java
@@ -35,7 +35,12 @@ public enum AppError {
 
   INTERNAL_SERVER_ERROR_REFRESH(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while refreshing the cached authorizations."),
 
-  INTERNAL_SERVER_ERROR_MULTIPLE_AUTHORIZATION_WITH_SAME_SUBKEY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "There are multiple authorization with the same subscription key [%s]. Please, check if they are correct.");
+  INTERNAL_SERVER_ERROR_MULTIPLE_AUTHORIZATION_WITH_SAME_SUBKEY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "There are multiple authorization with the same subscription key [%s]. Please, check if they are correct."),
+
+  INTERNAL_SERVER_ERROR_RETRIEVE_AUTHORIZED_ENTITY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while retrieving the authorized entity for domain [%s]."),
+
+  INTERNAL_SERVER_ERROR_GENERATE_AUTHORIZED_ENTITY(HttpStatus.INTERNAL_SERVER_ERROR, Constants.INTERNAL_SERVER_ERROR, "An error occurred while generating the authorized entity for domain [%s].")
+  ;
 
   public final HttpStatus httpStatus;
   public final String title;

--- a/src/main/java/it/gov/pagopa/authorizer/config/model/authorization/AuthorizedEntityList.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/model/authorization/AuthorizedEntityList.java
@@ -1,0 +1,41 @@
+package it.gov.pagopa.authorizer.config.model.authorization;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Data
+@Builder(toBuilder = true)
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@JsonPropertyOrder({"created_at", "domain", "size", "authorized_entities"})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthorizedEntityList implements Serializable {
+
+  @JsonProperty("created_at")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  @Schema(description = "The time on which the cached value was created.")
+  private LocalDateTime createdAt;
+
+  @JsonProperty("domain")
+  @Schema(description = "The domain related to the authorized entities.")
+  private String domain;
+
+  @JsonProperty("size")
+  @Schema(description = "The number of authorized entities stored.")
+  private Integer size;
+
+  @JsonProperty("authorized_entities")
+  @NotNull
+  @Schema(description = "The list of authorized entities retrieved from search in DB.", requiredMode = Schema.RequiredMode.REQUIRED)
+  private Set<String> authorizedEntities;
+}

--- a/src/main/java/it/gov/pagopa/authorizer/config/repository/AuthorizationRepository.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/repository/AuthorizationRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface AuthorizationRepository extends CosmosRepository<SubscriptionKeyDomain, String> {
@@ -20,6 +21,9 @@ public interface AuthorizationRepository extends CosmosRepository<SubscriptionKe
   List<SubscriptionKeyDomain> findByDomainAndOwnerId(@Param("domain") String domain, @Param("ownerId") String ownerId);
 
   List<SubscriptionKeyDomain> findByDomain(String domain);
+
+  @Query("SELECT DISTINCT VALUE e[\"value\"] FROM s JOIN e IN s.authorizedEntities WHERE s.domain = @domain")
+  Set<String> findAuthorizedEntitiesByDomain(String domain);
 
   Optional<SubscriptionKeyDomain> findBySubkey(String subkey);
 

--- a/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
@@ -1,0 +1,57 @@
+package it.gov.pagopa.authorizer.config.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import it.gov.pagopa.authorizer.config.exception.AppError;
+import it.gov.pagopa.authorizer.config.exception.AppException;
+import it.gov.pagopa.authorizer.config.repository.CachedAuthorizationRepository;
+import it.gov.pagopa.authorizer.config.service.AuthorizationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+public class AuthorizedEntitiesCacheScheduler {
+
+    @Autowired
+    private AuthorizationService authorizationService;
+
+    @Autowired
+    private CachedAuthorizationRepository cachedAuthorizationRepository;
+
+    @Value("${authorizer.cache.authorized-entities.lock.key-format}")
+    private String authorizedEntitiesDomainsLockKeyFormat;
+
+    @Value("${authorizer.schedule.authorized-entities.domains}")
+    private List<String> authorizedEntitiesDomains;
+
+    @Scheduled(cron = "${authorizer.schedule.authorized-entities.expression}")
+    public void autogenerateAuthorizedEntitiesCacheData() {
+        for (String domain : authorizedEntitiesDomains) {
+            if (lockForDomain(domain)) {
+                try {
+                    log.info("Starting autogeneration the list of authorized entities for domain [{}]...", domain);
+                    authorizationService.saveAuthorizedEntitiesInCache(domain);
+                    log.info("Autogeneration of the list of authorized entities for domain [{}] completed!", domain);
+                } catch (JsonProcessingException e) {
+                    log.error("An error occurred while autogenerating the list of authorized entities by domain.", e);
+                    throw new AppException(AppError.INTERNAL_SERVER_ERROR_GENERATE_AUTHORIZED_ENTITY, domain);
+                } finally {
+                    unlockForDomain(domain);
+                }
+            }
+        }
+    }
+
+    private boolean lockForDomain(String domain) {
+        return cachedAuthorizationRepository.saveIfAbsent(String.format(authorizedEntitiesDomainsLockKeyFormat, domain), true, 60);
+    }
+
+    private void unlockForDomain(String domain) {
+        cachedAuthorizationRepository.remove(String.format(authorizedEntitiesDomainsLockKeyFormat, domain));
+    }
+}

--- a/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
@@ -34,9 +34,9 @@ public class AuthorizedEntitiesCacheScheduler {
         for (String domain : authorizedEntitiesDomains) {
             if (lockForDomain(domain)) {
                 try {
-                    log.info("Starting autogeneration the list of authorized entities for domain [{}]...", domain);
+                    log.debug("Starting autogeneration the list of authorized entities for domain [{}]...", domain);
                     authorizationService.saveAuthorizedEntitiesInCache(domain);
-                    log.info("Autogeneration of the list of authorized entities for domain [{}] completed!", domain);
+                    log.debug("Autogeneration of the list of authorized entities for domain [{}] completed!", domain);
                 } catch (Exception e) {
                     log.error("An error occurred while autogenerating the list of authorized entities by domain.", e);
                 } finally {

--- a/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
@@ -17,10 +17,8 @@ import java.util.List;
 @Slf4j
 public class AuthorizedEntitiesCacheScheduler {
 
-    @Autowired
     private AuthorizationService authorizationService;
 
-    @Autowired
     private CachedAuthorizationRepository cachedAuthorizationRepository;
 
     @Value("${authorizer.cache.authorized-entities.lock.key-format}")
@@ -28,6 +26,12 @@ public class AuthorizedEntitiesCacheScheduler {
 
     @Value("${authorizer.schedule.authorized-entities.domains}")
     private List<String> authorizedEntitiesDomains;
+
+    public AuthorizedEntitiesCacheScheduler(AuthorizationService authorizationService,
+                                            CachedAuthorizationRepository cachedAuthorizationRepository) {
+        this.authorizationService = authorizationService;
+        this.cachedAuthorizationRepository = cachedAuthorizationRepository;
+    }
 
     @Scheduled(cron = "${authorizer.schedule.authorized-entities.expression}")
     public void autogenerateAuthorizedEntitiesCacheData() {

--- a/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
@@ -21,16 +21,18 @@ public class AuthorizedEntitiesCacheScheduler {
 
     private CachedAuthorizationRepository cachedAuthorizationRepository;
 
-    @Value("${authorizer.cache.authorized-entities.lock.key-format}")
     private String authorizedEntitiesDomainsLockKeyFormat;
 
-    @Value("${authorizer.schedule.authorized-entities.domains}")
     private List<String> authorizedEntitiesDomains;
 
     public AuthorizedEntitiesCacheScheduler(AuthorizationService authorizationService,
-                                            CachedAuthorizationRepository cachedAuthorizationRepository) {
+                                            CachedAuthorizationRepository cachedAuthorizationRepository,
+                                            @Value("${authorizer.cache.authorized-entities.lock.key-format}") String authorizedEntitiesDomainsLockKeyFormat,
+                                            @Value("${authorizer.schedule.authorized-entities.domains}") List<String> authorizedEntitiesDomains) {
         this.authorizationService = authorizationService;
         this.cachedAuthorizationRepository = cachedAuthorizationRepository;
+        this.authorizedEntitiesDomainsLockKeyFormat = authorizedEntitiesDomainsLockKeyFormat;
+        this.authorizedEntitiesDomains = authorizedEntitiesDomains;
     }
 
     @Scheduled(cron = "${authorizer.schedule.authorized-entities.expression}")

--- a/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduler.java
@@ -37,9 +37,8 @@ public class AuthorizedEntitiesCacheScheduler {
                     log.info("Starting autogeneration the list of authorized entities for domain [{}]...", domain);
                     authorizationService.saveAuthorizedEntitiesInCache(domain);
                     log.info("Autogeneration of the list of authorized entities for domain [{}] completed!", domain);
-                } catch (JsonProcessingException e) {
+                } catch (Exception e) {
                     log.error("An error occurred while autogenerating the list of authorized entities by domain.", e);
-                    throw new AppException(AppError.INTERNAL_SERVER_ERROR_GENERATE_AUTHORIZED_ENTITY, domain);
                 } finally {
                     unlockForDomain(domain);
                 }

--- a/src/main/java/it/gov/pagopa/authorizer/config/service/AuthorizationService.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/service/AuthorizationService.java
@@ -44,26 +44,30 @@ public class AuthorizationService {
 
   private ObjectMapper rawMapper;
 
-  @Value("${authorizer.configuration.limit}")
   private Integer configurationLimit;
 
-  @Value("${authorizer.configuration.offset}")
   private Integer configurationOffset;
 
-  @Value("${authorizer.cache.authorized-entities.key-format}")
   private String authorizedEntitiesDomainsKeyFormat;
 
-  @Value("${authorizer.cache.authorized-entities.ttl}")
   private Long authorizedEntitiesTTL;
 
   public AuthorizationService(CachedAuthorizationRepository cachedAuthorizationRepository,
                               AuthorizationRepository authorizationRepository,
                               ModelMapper modelMapper,
-                              ObjectMapper rawMapper) {
+                              ObjectMapper rawMapper,
+                              @Value("${authorizer.configuration.limit}") Integer configurationLimit,
+                              @Value("${authorizer.configuration.offset}") Integer configurationOffset,
+                              @Value("${authorizer.cache.authorized-entities.key-format}") String authorizedEntitiesDomainsKeyFormat,
+                              @Value("${authorizer.cache.authorized-entities.ttl}") Long authorizedEntitiesTTL) {
     this.cachedAuthorizationRepository = cachedAuthorizationRepository;
     this.authorizationRepository = authorizationRepository;
     this.modelMapper = modelMapper;
     this.rawMapper = rawMapper;
+    this.configurationLimit = configurationLimit;
+    this.configurationOffset = configurationOffset;
+    this.authorizedEntitiesDomainsKeyFormat = authorizedEntitiesDomainsKeyFormat;
+    this.authorizedEntitiesTTL = authorizedEntitiesTTL;
   }
 
   public AuthorizationList getAuthorizations(@NotBlank String domain, String ownerId, @NotNull Pageable pageable) {

--- a/src/main/java/it/gov/pagopa/authorizer/config/service/AuthorizationService.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/service/AuthorizationService.java
@@ -36,16 +36,12 @@ import java.util.stream.Collectors;
 @Slf4j
 public class AuthorizationService {
 
-  @Autowired
   private CachedAuthorizationRepository cachedAuthorizationRepository;
 
-  @Autowired
   private AuthorizationRepository authorizationRepository;
 
-  @Autowired
   private ModelMapper modelMapper;
 
-  @Autowired
   private ObjectMapper rawMapper;
 
   @Value("${authorizer.configuration.limit}")
@@ -59,6 +55,16 @@ public class AuthorizationService {
 
   @Value("${authorizer.cache.authorized-entities.ttl}")
   private Long authorizedEntitiesTTL;
+
+  public AuthorizationService(CachedAuthorizationRepository cachedAuthorizationRepository,
+                              AuthorizationRepository authorizationRepository,
+                              ModelMapper modelMapper,
+                              ObjectMapper rawMapper) {
+    this.cachedAuthorizationRepository = cachedAuthorizationRepository;
+    this.authorizationRepository = authorizationRepository;
+    this.modelMapper = modelMapper;
+    this.rawMapper = rawMapper;
+  }
 
   public AuthorizationList getAuthorizations(@NotBlank String domain, String ownerId, @NotNull Pageable pageable) {
     Page<SubscriptionKeyDomain> page;

--- a/src/main/java/it/gov/pagopa/authorizer/config/service/AuthorizationService.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/service/AuthorizationService.java
@@ -241,7 +241,10 @@ public class AuthorizationService {
     authorizedEntities.setCreatedAt(LocalDateTime.now());
     // If something is found, store the list of authorized entities in Redis storage
     if (!authorizedEntitiesByDomain.isEmpty()) {
-      cachedAuthorizationRepository.save(String.format(authorizedEntitiesDomainsKeyFormat, domain), rawMapper.writeValueAsString(authorizedEntities), authorizedEntitiesTTL);
+      cachedAuthorizationRepository.save(
+              String.format(authorizedEntitiesDomainsKeyFormat, domain),
+              rawMapper.writeValueAsString(authorizedEntities),
+              authorizedEntitiesTTL);
     }
     return authorizedEntities;
   }

--- a/src/main/java/it/gov/pagopa/authorizer/config/service/EnrolledOrganizationService.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/service/EnrolledOrganizationService.java
@@ -39,15 +39,19 @@ public class EnrolledOrganizationService {
   @Value("${client.apiconfig-selfcare.uri}")
   private String apiconfigSelfcareIntegrationURI;
 
-  @Autowired
   private AuthorizationRepository authorizationRepository;
 
-  @Autowired
   private ObjectMapper jsonParser;
 
-  @Autowired
-  @Qualifier("apiconfigSelfcareClient")
   private WebClient apiconfigSelfcareClient;
+
+  public EnrolledOrganizationService(AuthorizationRepository authorizationRepository,
+                                     ObjectMapper jsonParser,
+                                     @Qualifier("apiconfigSelfcareClient") WebClient apiconfigSelfcareClient) {
+    this.authorizationRepository = authorizationRepository;
+    this.jsonParser = jsonParser;
+    this.apiconfigSelfcareClient = apiconfigSelfcareClient;
+  }
 
   public EnrolledCreditorInstitutionList getEnrolledOrganizations(@NotNull String domain) {
     List<SubscriptionKeyDomain> subscriptionKeyDomains = authorizationRepository.findByDomain(domain);

--- a/src/main/java/it/gov/pagopa/authorizer/config/util/Constants.java
+++ b/src/main/java/it/gov/pagopa/authorizer/config/util/Constants.java
@@ -19,4 +19,6 @@ public class Constants {
   public static final String WILDCARD_CHARACTER = "*";
 
   public static final String INTERNAL_SERVER_ERROR = "Internal Server Error";
+
+  public static final String MDC_MAX_RESPONSE_BODY_SIZE_FOR_LOG = "maxResponseBodySizeForLog";
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -55,8 +55,16 @@ spring.redis.password=${REDIS_PASSWORD}
 # Authorizer configurator parameters
 authorizer.cache.authorization.key-format=default-workspace_2_authorizer_%s_%s
 authorizer.cache.authorization.lock-key-format=default-workspace_2_authorizer_%s
+authorizer.cache.authorized-entities.key-format=authorizer_enrolled_%s
+authorizer.cache.authorized-entities.lock.key-format=authorizer_enrolled_%s_lock
+authorizer.cache.authorized-entities.ttl=${CACHE_AUTHORIZED_ENTITIES_TTL:86400}
 authorizer.configuration.limit=${CONFIGURATION_LIMIT:1000}
 authorizer.configuration.offset=${CONFIGURATION_OFFSET:0}
+
+# Authorizer configurator's batch parameters
+authorizer.schedule.enabled=${SCHEDULER_ENABLED:true}
+authorizer.schedule.authorized-entities.expression=${AUTOCACHE_SCHEDULE_CRON:0 0 */12 * * *}
+authorizer.schedule.authorized-entities.domains=${AUTOCACHE_SCHEDULE_DOMAINS:gpd,aca}
 
 # Client setting
 client.common.readTimeout=${CLIENT_READ_TIMEOUT}

--- a/src/test/java/it/gov/pagopa/authorizer/config/controller/AuthorizationControllerTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/controller/AuthorizationControllerTest.java
@@ -274,4 +274,41 @@ class AuthorizationControllerTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON));
   }
 
+  @Test
+  void getAuthorizedEntitiesByDomain_200() throws Exception {
+    String domain = "existing-domain";
+    String url = String.format("/authorizations/domains/%s/authorizedentities", domain);
+    // mocking invocation
+    when(authorizationService.getAuthorizedEntitiesByDomain(anyString()))
+            .thenReturn(TestUtil.getAuthorizedEntities(domain, 50000));
+    // executing API call
+    mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void getAuthorizedEntitiesByDomain_500_errorInGeneration() throws Exception {
+    String domain = "existing-domain";
+    String url = String.format("/authorizations/domains/%s/authorizedentities", domain);
+    // mocking invocation
+    when(authorizationService.getAuthorizedEntitiesByDomain(anyString())).thenThrow(new AppException(AppError.INTERNAL_SERVER_ERROR_GENERATE_AUTHORIZED_ENTITY, domain));
+    // executing API call
+    mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void getAuthorizedEntitiesByDomain_500_errorInParsing() throws Exception {
+    String domain = "existing-domain";
+    String url = String.format("/authorizations/domains/%s/authorizedentities", domain);
+    // mocking invocation
+    when(authorizationService.getAuthorizedEntitiesByDomain(anyString())).thenThrow(new AppException(AppError.INTERNAL_SERVER_ERROR_RETRIEVE_AUTHORIZED_ENTITY, domain));
+    // executing API call
+    mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+  }
+
 }

--- a/src/test/java/it/gov/pagopa/authorizer/config/controller/AuthorizationControllerTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/controller/AuthorizationControllerTest.java
@@ -288,18 +288,6 @@ class AuthorizationControllerTest {
   }
 
   @Test
-  void getAuthorizedEntitiesByDomain_500_errorInGeneration() throws Exception {
-    String domain = "existing-domain";
-    String url = String.format("/authorizations/domains/%s/authorizedentities", domain);
-    // mocking invocation
-    when(authorizationService.getAuthorizedEntitiesByDomain(anyString())).thenThrow(new AppException(AppError.INTERNAL_SERVER_ERROR_GENERATE_AUTHORIZED_ENTITY, domain));
-    // executing API call
-    mvc.perform(get(url).contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isInternalServerError())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
-  }
-
-  @Test
   void getAuthorizedEntitiesByDomain_500_errorInParsing() throws Exception {
     String domain = "existing-domain";
     String url = String.format("/authorizations/domains/%s/authorizedentities", domain);

--- a/src/test/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduleTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduleTest.java
@@ -1,0 +1,99 @@
+package it.gov.pagopa.authorizer.config.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.gov.pagopa.authorizer.config.Application;
+import it.gov.pagopa.authorizer.config.exception.AppError;
+import it.gov.pagopa.authorizer.config.exception.AppException;
+import it.gov.pagopa.authorizer.config.model.authorization.AuthorizedEntityList;
+import it.gov.pagopa.authorizer.config.repository.AuthorizationRepository;
+import it.gov.pagopa.authorizer.config.repository.CachedAuthorizationRepository;
+import it.gov.pagopa.authorizer.config.service.AuthorizationService;
+import it.gov.pagopa.authorizer.config.util.TestUtil;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(classes = Application.class)
+public class AuthorizedEntitiesCacheScheduleTest {
+
+    @MockBean private AuthorizationRepository authorizationRepository;
+
+    @MockBean private CachedAuthorizationRepository cachedAuthorizationRepository;
+
+    @Autowired @InjectMocks private AuthorizedEntitiesCacheScheduler authorizedEntitiesCacheScheduler;
+
+    @ParameterizedTest
+    @CsvSource({
+            "domain1,1000",
+            "domain1;domain2,1000",
+            "domain1;domain2;domain3,10000",
+            "domain1;domain2;domain3;domain4;domain5,50000"
+    })
+    public void autogenerateAuthorizedEntitiesCacheData_ok(String rawDomains, String rawSize) {
+        // Mocking objects
+        List<String> domains = List.of(rawDomains.split(";"));
+        int numberOfDomains = domains.size();
+        int size = Integer.parseInt(rawSize);
+        Set<String> authorizedEntitiesIdentifiers = TestUtil.getAuthorizedEntitiesIdentifiers(size);
+        authorizedEntitiesIdentifiers.add("*"); // force wildcard setting
+        ReflectionTestUtils.setField(authorizedEntitiesCacheScheduler, "authorizedEntitiesDomains", domains);
+        when(cachedAuthorizationRepository.saveIfAbsent(anyString(), any(), anyLong())).thenReturn(true);
+        when(authorizationRepository.findAuthorizedEntitiesByDomain(anyString())).thenReturn(authorizedEntitiesIdentifiers);
+        // executing logic
+        authorizedEntitiesCacheScheduler.autogenerateAuthorizedEntitiesCacheData();
+        // executing assertion check
+        verify(cachedAuthorizationRepository, times(numberOfDomains)).saveIfAbsent(anyString(), any(), anyLong());
+        verify(authorizationRepository, times(numberOfDomains)).findAuthorizedEntitiesByDomain(anyString());
+        verify(cachedAuthorizationRepository, times(numberOfDomains)).save(anyString(), any(), anyLong());
+        verify(cachedAuthorizationRepository, times(numberOfDomains)).remove(anyString());
+    }
+
+    @Test
+    public void autogenerateAuthorizedEntitiesCacheData_ok_noDomains() {
+        // Mocking objects
+        ReflectionTestUtils.setField(authorizedEntitiesCacheScheduler, "authorizedEntitiesDomains", List.of());
+        // executing logic
+        authorizedEntitiesCacheScheduler.autogenerateAuthorizedEntitiesCacheData();
+        // executing assertion check
+        verify(cachedAuthorizationRepository, times(0)).saveIfAbsent(anyString(), any(), anyLong());
+        verify(authorizationRepository, times(0)).findAuthorizedEntitiesByDomain(anyString());
+        verify(cachedAuthorizationRepository, times(0)).save(anyString(), any(), anyLong());
+        verify(cachedAuthorizationRepository, times(0)).remove(anyString());
+    }
+
+    @Test
+    @SneakyThrows
+    public void autogenerateAuthorizedEntitiesCacheData_error() {
+        // Mocking objects
+        List<String> domains = List.of("domain1", "domain2");
+        int numberOfDomains = domains.size();
+        int size = 1000;
+        Set<String> authorizedEntitiesIdentifiers = TestUtil.getAuthorizedEntitiesIdentifiers(size);
+        authorizedEntitiesIdentifiers.add("*"); // force wildcard setting
+        ReflectionTestUtils.setField(authorizedEntitiesCacheScheduler, "authorizedEntitiesDomains", domains);
+        when(cachedAuthorizationRepository.saveIfAbsent(anyString(), any(), anyLong())).thenReturn(true);
+        when(authorizationRepository.findAuthorizedEntitiesByDomain(anyString())).thenThrow(RuntimeException.class);
+        // executing logic
+        authorizedEntitiesCacheScheduler.autogenerateAuthorizedEntitiesCacheData();
+        // executing assertion check
+        verify(cachedAuthorizationRepository, times(numberOfDomains)).saveIfAbsent(anyString(), any(), anyLong());
+        verify(authorizationRepository, times(numberOfDomains)).findAuthorizedEntitiesByDomain(anyString());
+        verify(cachedAuthorizationRepository, times(0)).save(anyString(), any(), anyLong());
+        verify(cachedAuthorizationRepository, times(numberOfDomains)).remove(anyString());
+    }
+}

--- a/src/test/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduleTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/scheduler/AuthorizedEntitiesCacheScheduleTest.java
@@ -29,7 +29,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest(classes = Application.class)
-public class AuthorizedEntitiesCacheScheduleTest {
+class AuthorizedEntitiesCacheScheduleTest {
 
     @MockBean private AuthorizationRepository authorizationRepository;
 
@@ -44,7 +44,7 @@ public class AuthorizedEntitiesCacheScheduleTest {
             "domain1;domain2;domain3,10000",
             "domain1;domain2;domain3;domain4;domain5,50000"
     })
-    public void autogenerateAuthorizedEntitiesCacheData_ok(String rawDomains, String rawSize) {
+    void autogenerateAuthorizedEntitiesCacheData_ok(String rawDomains, String rawSize) {
         // Mocking objects
         List<String> domains = List.of(rawDomains.split(";"));
         int numberOfDomains = domains.size();
@@ -64,7 +64,7 @@ public class AuthorizedEntitiesCacheScheduleTest {
     }
 
     @Test
-    public void autogenerateAuthorizedEntitiesCacheData_ok_noDomains() {
+    void autogenerateAuthorizedEntitiesCacheData_ok_noDomains() {
         // Mocking objects
         ReflectionTestUtils.setField(authorizedEntitiesCacheScheduler, "authorizedEntitiesDomains", List.of());
         // executing logic
@@ -78,7 +78,7 @@ public class AuthorizedEntitiesCacheScheduleTest {
 
     @Test
     @SneakyThrows
-    public void autogenerateAuthorizedEntitiesCacheData_error() {
+    void autogenerateAuthorizedEntitiesCacheData_error() {
         // Mocking objects
         List<String> domains = List.of("domain1", "domain2");
         int numberOfDomains = domains.size();

--- a/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
@@ -23,7 +23,6 @@ import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import javax.persistence.NonUniqueResultException;
 import java.util.List;
 import java.util.Optional;
 
@@ -287,7 +286,7 @@ class AuthorizationServiceTest {
         // Mocking objects
         when(authorizationRepository.findById(id)).thenReturn(Optional.ofNullable(TestUtil.getSubscriptionKeyDomain(1, id, "gpd", "fakedomain")));
         doNothing().when(authorizationRepository).delete(any(SubscriptionKeyDomain.class));
-        doNothing().when(cachedAuthorizationRepository).remove(anyString(), anyString(), anyString());
+        doNothing().when(cachedAuthorizationRepository).removeSubscriptionKey(anyString(), anyString(), anyString());
         // executing logic
         assertDoesNotThrow(() -> authorizationService.deleteAuthorization(id, null));
     }

--- a/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
@@ -469,7 +469,7 @@ class AuthorizationServiceTest {
     }
 
     @Test
-    void getAuthorizedEntitiesByDomain_200_noData() throws JsonProcessingException {
+    void getAuthorizedEntitiesByDomain_200_noData() {
         // Mocking objects
         String domain = "fake-domain";
         int size = 0;

--- a/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
@@ -27,6 +27,7 @@ import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -473,7 +474,7 @@ class AuthorizationServiceTest {
         String domain = "fake-domain";
         int size = 0;
         when(cachedAuthorizationRepository.read(domain)).thenReturn(Set.of());
-        when(authorizationRepository.findAuthorizedEntitiesByDomain(domain)).thenReturn(Set.of());
+        when(authorizationRepository.findAuthorizedEntitiesByDomain(domain)).thenReturn(new HashSet<>());
         // executing logic
         AuthorizedEntityList result = authorizationService.getAuthorizedEntitiesByDomain(domain);
         // executing assertion check

--- a/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/service/AuthorizationServiceTest.java
@@ -1,12 +1,16 @@
 package it.gov.pagopa.authorizer.config.service;
 
 import com.azure.spring.data.cosmos.exception.CosmosAccessException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import it.gov.pagopa.authorizer.config.Application;
 import it.gov.pagopa.authorizer.config.entity.SubscriptionKeyDomain;
 import it.gov.pagopa.authorizer.config.exception.AppError;
 import it.gov.pagopa.authorizer.config.exception.AppException;
 import it.gov.pagopa.authorizer.config.model.authorization.Authorization;
 import it.gov.pagopa.authorizer.config.model.authorization.AuthorizationList;
+import it.gov.pagopa.authorizer.config.model.authorization.AuthorizedEntityList;
 import it.gov.pagopa.authorizer.config.model.cachedauthorization.CachedAuthorizationList;
 import it.gov.pagopa.authorizer.config.repository.AuthorizationRepository;
 import it.gov.pagopa.authorizer.config.repository.CachedAuthorizationRepository;
@@ -25,6 +29,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -408,5 +413,92 @@ class AuthorizationServiceTest {
         // executing assertion check
         assertEquals(AppError.INTERNAL_SERVER_ERROR.httpStatus, exception.getHttpStatus());
         assertEquals(AppError.INTERNAL_SERVER_ERROR.title, exception.getTitle());
+    }
+
+
+
+
+    @ParameterizedTest
+    @CsvSource({
+            "small-domain,10",
+            "medium-domain,1000",
+            "big-domain,10000",
+            "huge-domain,50000",
+    })
+    void getAuthorizedEntitiesByDomain_200_notPreviouslyCached(String domain, String rawSize) {
+        // Mocking objects
+        int size = Integer.parseInt(rawSize);
+        Set<String> authorizedEntitiesIdentifiers = TestUtil.getAuthorizedEntitiesIdentifiers(size);
+        authorizedEntitiesIdentifiers.add("*"); // force wildcard setting
+        when(cachedAuthorizationRepository.read(domain)).thenReturn(Set.of());
+        when(authorizationRepository.findAuthorizedEntitiesByDomain(domain)).thenReturn(authorizedEntitiesIdentifiers);
+        // executing logic
+        AuthorizedEntityList result = authorizationService.getAuthorizedEntitiesByDomain(domain);
+        // executing assertion check
+        assertNotNull(result);
+        assertEquals((int) result.getSize(), size);
+        assertEquals(domain, result.getDomain());
+        assertEquals(result.getAuthorizedEntities().size(), size);
+        assertNotNull(result.getCreatedAt());
+        assertFalse(result.getAuthorizedEntities().contains("*"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "small-domain,10",
+            "medium-domain,1000",
+            "big-domain,10000",
+            "huge-domain,50000",
+    })
+    void getAuthorizedEntitiesByDomain_200_previouslyCached(String domain, String rawSize) throws JsonProcessingException {
+        // Mocking objects
+        int size = Integer.parseInt(rawSize);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        String mockedCachedContent = objectMapper.writeValueAsString(TestUtil.getAuthorizedEntities(domain, size));
+        when(cachedAuthorizationRepository.read(anyString())).thenReturn(mockedCachedContent);
+        // executing logic
+        AuthorizedEntityList result = authorizationService.getAuthorizedEntitiesByDomain(domain);
+        // executing assertion check
+        assertNotNull(result);
+        assertEquals((int) result.getSize(), size);
+        assertEquals(domain, result.getDomain());
+        assertEquals(result.getAuthorizedEntities().size(), size);
+        assertNotNull(result.getCreatedAt());
+    }
+
+    @Test
+    void getAuthorizedEntitiesByDomain_200_noData() throws JsonProcessingException {
+        // Mocking objects
+        String domain = "fake-domain";
+        int size = 0;
+        when(cachedAuthorizationRepository.read(domain)).thenReturn(Set.of());
+        when(authorizationRepository.findAuthorizedEntitiesByDomain(domain)).thenReturn(Set.of());
+        // executing logic
+        AuthorizedEntityList result = authorizationService.getAuthorizedEntitiesByDomain(domain);
+        // executing assertion check
+        assertNotNull(result);
+        assertEquals(size, (int) result.getSize());
+        assertEquals(domain, result.getDomain());
+        assertEquals(size, result.getAuthorizedEntities().size());
+        assertNotNull(result.getCreatedAt());
+    }
+
+    @Test
+    void getAuthorizedEntitiesByDomain_500() throws JsonProcessingException {
+        // Mocking objects
+        String domain = "fake-domain";
+        int size = 10;
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        String mockedCachedContent = objectMapper.writeValueAsString(TestUtil.getAuthorizedEntities(domain, size));
+        mockedCachedContent = mockedCachedContent.substring(0, mockedCachedContent.length() - 5);
+        when(cachedAuthorizationRepository.read(anyString())).thenReturn(mockedCachedContent);
+        // executing logic
+        AppException exception = assertThrows(AppException.class, () -> authorizationService.getAuthorizedEntitiesByDomain(domain));
+        // executing assertion check
+        assertEquals(AppError.INTERNAL_SERVER_ERROR_RETRIEVE_AUTHORIZED_ENTITY.httpStatus, exception.getHttpStatus());
+        assertEquals(AppError.INTERNAL_SERVER_ERROR_RETRIEVE_AUTHORIZED_ENTITY.title, exception.getTitle());
+        verify(cachedAuthorizationRepository, never()).save(anyString(), any(), anyLong());
     }
 }

--- a/src/test/java/it/gov/pagopa/authorizer/config/util/TestUtil.java
+++ b/src/test/java/it/gov/pagopa/authorizer/config/util/TestUtil.java
@@ -23,10 +23,8 @@ import org.springframework.data.domain.PageImpl;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.time.LocalDateTime;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -268,5 +266,23 @@ public class TestUtil {
                     .build();
         }
         return result;
+    }
+
+
+    public AuthorizedEntityList getAuthorizedEntities(String domain, int size) {
+        return AuthorizedEntityList.builder()
+                .size(size)
+                .createdAt(LocalDateTime.now())
+                .domain(domain)
+                .authorizedEntities(getAuthorizedEntitiesIdentifiers(size))
+                .build();
+    }
+
+    public Set<String> getAuthorizedEntitiesIdentifiers(int number) {
+        Set<String> authorizedEntitiesIdentifiers = new HashSet<>();
+        for (int i = 0; i < number; i ++) {
+            authorizedEntitiesIdentifiers.add(String.format("%07d", i));
+        }
+        return authorizedEntitiesIdentifiers;
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -55,8 +55,16 @@ spring.redis.password=1
 # Authorizer configurator parameters
 authorizer.cache.authorization.key-format=default-workspace_2_authorizer_%s_%s
 authorizer.cache.authorization.lock-key-format=default-workspace_2_authorizer_%s
+authorizer.cache.authorized-entities.key-format=authorizer_enrolled_%s
+authorizer.cache.authorized-entities.lock.key-format=authorizer_enrolled_%s_lock
+authorizer.cache.authorized-entities.ttl=86400
 authorizer.configuration.limit=1000
 authorizer.configuration.offset=0
+
+# Authorizer configurator's batch parameters
+authorizer.schedule.enabled=true
+authorizer.schedule.authorized-entities.expression=0 0 */12 * * *
+authorizer.schedule.authorized-entities.domains=gpd,aca
 
 # Client setting
 client.common.readTimeout=1


### PR DESCRIPTION
This PR introduce a new operative functionality on Authorizer system. In particular, this microservice from now will provide the generation of enrolled authorized entities, extracted from authorization documents. The generated data is stored in Redis cache storage via scheduled process. This is made in order to being easily and faster retrieved using a new API, invocable by stakeholders that need updated data.  

#### List of Changes
 - Defined cron process for generate cached enrolled authorized entities 
 - Defined new API for retrieve enrolled authorized entities on-demand
 - Reduced logged content by truncating message after required maximum size

#### Motivation and Context
These changes permit to add a new functionality on Authorizer context. 

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in DEV environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Related PRs:
 - https://github.com/pagopa/pagopa-infra/pull/3319