### PR TITLE
fix: Changing secret for `OTEL_EXPORTER_OTLP_HEADERS`

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-platform-authorizer-config
 description: Microservice that provides a set of APIs to manage authorization records for the Authorizer system.
 type: application
-version: 0.49.0
-appVersion: 0.2.19
+version: 0.50.0
+appVersion: 0.2.19-1-fix-otlp-headers
 dependencies:
   - name: microservice-chart
     version: 7.5.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-platform-authorizer-config
-    tag: "0.2.19"
+    tag: "0.2.19-1-fix-otlp-headers"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -87,7 +87,7 @@ microservice-chart:
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"
   envSecret:
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-d-connection-string'
-    OTEL_EXPORTER_OTLP_HEADERS: 'elastic-otel-token-header'
+    OTEL_EXPORTER_OTLP_HEADERS: 'elastic-apm-secret-token'
     COSMOS_KEY: 'auth-d-cosmos-key'
     REDIS_PASSWORD: 'redis-password'
     REDIS_HOST: 'redis-hostname'

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-platform-authorizer-config
-    tag: "0.2.19"
+    tag: "0.2.19-1-fix-otlp-headers"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -89,7 +89,7 @@ microservice-chart:
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"
   envSecret:
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-p-connection-string'
-    OTEL_EXPORTER_OTLP_HEADERS: 'elastic-otel-token-header'
+    OTEL_EXPORTER_OTLP_HEADERS: 'elastic-apm-secret-token'
     COSMOS_KEY: 'auth-p-cosmos-key'
     REDIS_PASSWORD: 'redis-password'
     REDIS_HOST: 'redis-hostname'

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-platform-authorizer-config
-    tag: "0.2.19"
+    tag: "0.2.19-1-fix-otlp-headers"
     pullPolicy: Always
   livenessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -87,7 +87,7 @@ microservice-chart:
     APP_VERSION: "metadata.labels['app.kubernetes.io/version']"
   envSecret:
     APPLICATIONINSIGHTS_CONNECTION_STRING: 'ai-u-connection-string'
-    OTEL_EXPORTER_OTLP_HEADERS: 'elastic-otel-token-header'
+    OTEL_EXPORTER_OTLP_HEADERS: 'elastic-apm-secret-token'
     COSMOS_KEY: 'auth-u-cosmos-key'
     REDIS_PASSWORD: 'redis-password'
     REDIS_HOST: 'redis-hostname'

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -4,7 +4,7 @@
     "title": "platform-authorizer-config",
     "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.19"
+    "version": "0.2.19-1-fix-otlp-headers"
   },
   "servers": [
     {

--- a/openapi/openapi_core.json
+++ b/openapi/openapi_core.json
@@ -4,7 +4,7 @@
     "title": "platform-authorizer-config",
     "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.19"
+    "version": "0.2.19-1-fix-otlp-headers"
   },
   "servers": [
     {

--- a/openapi/openapi_enrolledci.json
+++ b/openapi/openapi_enrolledci.json
@@ -4,7 +4,7 @@
     "title": "platform-authorizer-config",
     "description": "A microservice that provides a set of APIs to manage authorization records for the Authorizer system.",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "0.2.19"
+    "version": "0.2.19-1-fix-otlp-headers"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>it.gov.pagopa</groupId>
   <artifactId>platform-authorizer-config</artifactId>
-  <version>0.2.19</version>
+  <version>0.2.19-1-fix-otlp-headers</version>
   <name>pagopa-platform-authorizer-config</name>
   <description>A microservice that provides a set of APIs to manage authorization records for the Authorizer system.</description>
 


### PR DESCRIPTION

Motivation and context



#### List of Changes
 - Migrated towards `elastic-otel-token-header` secret key

#### Motivation and Context
The `elastic-otel-token-header` secret key in `shared`'s domain KeyVault is removed because its value is incorrectly (the value never changed from `<TO UPDATE MANUALLY ON PORTAL>` placeholder) and it is a duplicate of `elastic-apm-secret-token` secret.

#### How Has This Been Tested?
 - Tested in DEV environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.